### PR TITLE
Remove "Running" from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Pending
 
 ### Running:
 
-Open the shell script, which you want to beautify, in sublime-text and press `Control+Shift+b`.
+Pending
 
 ________________________________________________________________________________
 


### PR DESCRIPTION
Users would get confused if "Running" section shows some unworkable instruction. We should put it back on README once PackageControl thing is done.