### PR TITLE
fixed broken function beautify if there are any non alphanumeric char…

### DIFF
--- a/beautysh/beautysh.py
+++ b/beautysh/beautysh.py
@@ -12,9 +12,9 @@ import pkg_resources  # part of setuptools
 # 1) function keyword, NO open/closed parentheses, e.g.   function foo
 # 2) NO function keyword, open/closed parentheses, e.g.   foo()
 FUNCTION_STYLE_REGEX = [
-    r'\bfunction\s+(\w*)\s*\(\s*\)\s*',
-    r'\bfunction\s+(\w*)\s*',
-    r'\b\s*(\w*)\s*\(\s*\)\s*'
+    r'\bfunction\s+(.*)\s*\(\s*\)\s*',
+    r'\bfunction\s+(.*)\s*',
+    r'\b\s*(.*)\s*\(\s*\)\s*'
 ]
 
 FUNCTION_STYLE_REPLACEMENT = [


### PR DESCRIPTION
First off thank you for this program, I use it all the time and love it!

I just happened to notice that when you have functions with any non alphanumeric characters in them, it breaks those functions upon beautifying (and happens with all function styles). 

A few examples would be:
```
function do-something-test (){}' 
do-something-test () {}` 
```
etc...

I was able to fix this by a small regex change (replace `\w` with `.`) and it seems to resolve this bug. I didn't extensively test it, but it seems to work well with all the test cases I could come up with.

I hope this solution helps, or at least brings the issue to light so it can be resolved! (you may have a better way to fix it...who knows :-) )

best, Jared
