### PR TITLE
Fix outdent issues for elif (#2, #57)

### DIFF
--- a/beautysh/beautysh.py
+++ b/beautysh/beautysh.py
@@ -232,9 +232,9 @@ class Beautify:
                         if func_decl_style != None:
                              stripped_record = self.change_function_style(stripped_record, func_decl_style)
 
-                        # an ad-hoc solution for the "else" or "elif" keyword
-                        else_case = (0, -1)[re.search(r'^(else|elif)',
-                                            test_record) is not None]
+                        # an ad-hoc solution for the "else" or "elif ... then" keywords
+                        else_case = (0, -1)[re.search(r'^(else|elif\s.*?;\s+?then)', test_record) is not None]
+                        
                         net = inc - outc
                         tab += min(net, 0)
 


### PR DESCRIPTION
Make the ad-hoc oudent (added in #2) apply only when `elif` is followed by `then` on the same line. In my testing, this addresses #57 without breaking the #2 test case. I'm sure the regex could be cleaned up, though.