### PR TITLE
chore(flake/poetry2nix): `705cbfa1` -> `5aa37b8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1633382856,
-        "narHash": "sha256-hYlet806M9xJj4yxf0g5fhDT2IEUVIMAl7sqIeZ8DUM=",
+        "lastModified": 1643757111,
+        "narHash": "sha256-LerUUhM/srtbYgc8x0+sIiTUv3FfjeNLxjZqZ/DQzlo=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "705cbfa10e3d9bfed2e59e0256844ae3704dbd7e",
+        "rev": "5aa37b8a5652a4c2a2372e82815ebd15db07f087",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                    | Commit Message                                                                                            |
| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
| [`ea15a005`](https://github.com/nix-community/poetry2nix/commit/ea15a00506d0c183064cbc73b687c6be1c0c36b0) | `A few fixes to various packages`                                                                         |
| [`bd2ada93`](https://github.com/nix-community/poetry2nix/commit/bd2ada9339215992913b0f9fa145d2e33a570adb) | `Add mkdocs-jupyter`                                                                                      |
| [`9c5c872e`](https://github.com/nix-community/poetry2nix/commit/9c5c872ee34e4bfddb5b53ecb72051d57310ddc6) | `Add more build-systems overrides`                                                                        |
| [`4f476e3b`](https://github.com/nix-community/poetry2nix/commit/4f476e3b5715f9bc983e048bca02127b4789017e) | `Sort keys of build-systems.json`                                                                         |
| [`11f987bb`](https://github.com/nix-community/poetry2nix/commit/11f987bbeceb7165e6e9e71955b2f4a487a697bd) | `Add more build systems`                                                                                  |
| [`7dff6e42`](https://github.com/nix-community/poetry2nix/commit/7dff6e4238cde2e693aabbb9cbbaf9663111fffb) | `overrides.igraph: add override`                                                                          |
| [`2b413427`](https://github.com/nix-community/poetry2nix/commit/2b413427c1613e84edbe274977130e9c0b21f354) | `Document explaining known issues with python packages`                                                   |
| [`59bf583e`](https://github.com/nix-community/poetry2nix/commit/59bf583eed2409b43964eae48daedbbee0e17c0d) | `overrides.uwsgi: only change sourceRoot for 2.0.19.x`                                                    |
| [`9bdb1e72`](https://github.com/nix-community/poetry2nix/commit/9bdb1e7226f684e9db9f9db1527cbf34763b06ea) | `Build system for requirements-parser`                                                                    |
| [`66d577cd`](https://github.com/nix-community/poetry2nix/commit/66d577cdadc75625eb4bda1165be528f2b7659e6) | `More build requirements`                                                                                 |
| [`d2840030`](https://github.com/nix-community/poetry2nix/commit/d2840030781c547410338b0bbc8f4017ed3c02aa) | `Added build-system for unknown packages`                                                                 |
| [`4022cbc8`](https://github.com/nix-community/poetry2nix/commit/4022cbc823436a576d4eed870aa4c9decc13e6f3) | `overrides: Assorted fixes`                                                                               |
| [`c667bfa5`](https://github.com/nix-community/poetry2nix/commit/c667bfa5290119b763747471e02644a7bc09629a) | `Skip failing tests on darwin`                                                                            |
| [`ab4aef70`](https://github.com/nix-community/poetry2nix/commit/ab4aef7037e0f37c77f0c5d8540828d33cd9ea5b) | `Enable CI on MacOS`                                                                                      |
| [`0a6d2240`](https://github.com/nix-community/poetry2nix/commit/0a6d22407cb8cecad7e68eb1557818fdceddb5a7) | `overrides.matplotlib: Hopefully fix darwin build`                                                        |
| [`47ec0732`](https://github.com/nix-community/poetry2nix/commit/47ec0732956787a7491501c4e8b0cc58456ad1ae) | `overrides.matplotlib: Don't copy mplsetup.cfg`                                                           |
| [`c60eba60`](https://github.com/nix-community/poetry2nix/commit/c60eba609eccdc4930c386a02442b73700f901d4) | `overrides.cryptography: Fix darwin build by adding iconv`                                                |
| [`0f409520`](https://github.com/nix-community/poetry2nix/commit/0f409520138dbb6baea14b69a785dc5c126cf7fa) | `Show full log in build output in CI`                                                                     |
| [`e3fff9ae`](https://github.com/nix-community/poetry2nix/commit/e3fff9ae959678e1d03a961db59dc251cd279ce3) | `overrides.aiosqlite: Use flit, not poetry`                                                               |
| [`1d62cb77`](https://github.com/nix-community/poetry2nix/commit/1d62cb77e69ff6d3939f9fe70c44e37d1640cb79) | `overrides;pendulum: Remove explicit override`                                                            |
| [`bb918a65`](https://github.com/nix-community/poetry2nix/commit/bb918a65defc4bfeb932a28152d0c73a96e35740) | `overrides: pkgs.lib -> lib`                                                                              |
| [`6c2c497a`](https://github.com/nix-community/poetry2nix/commit/6c2c497a29243ab913f4c3e3c9e51f39b8af6baf) | `Add cython to derived overrides script`                                                                  |
| [`849e0e3c`](https://github.com/nix-community/poetry2nix/commit/849e0e3ca494970291357926c4f19a57e5c1b6ad) | `overrides: Move build-systems to separate file which can be automatically generated`                     |
| [`044d7d70`](https://github.com/nix-community/poetry2nix/commit/044d7d70fc36fec6f54c1ace5703498d00d4ed17) | `Add development tool to automatically derive build-systems from nixpkgs`                                 |
| [`e6433fee`](https://github.com/nix-community/poetry2nix/commit/e6433fee566c8833ceae475eb3b8ecdcc18f7ccf) | `overrides.nix: Move into overrides/default.nix`                                                          |
| [`c3642f53`](https://github.com/nix-community/poetry2nix/commit/c3642f536839e40ed730ce8124866137e2d92552) | `overrides: Add assorted overrides to fix build-system dependencies`                                      |
| [`f4dcab73`](https://github.com/nix-community/poetry2nix/commit/f4dcab7362b21252c99a6edd70cd2876671e8c1d) | `Add assorted-pkgs test`                                                                                  |
| [`a032307e`](https://github.com/nix-community/poetry2nix/commit/a032307edd3b0d8a0b0342877ba6b3afca8622e4) | `Add extended cross test`                                                                                 |
| [`1011a79c`](https://github.com/nix-community/poetry2nix/commit/1011a79c9513c472af574b7c20fb75c74aaa44e5) | `overrides: Fix various cross issues`                                                                     |
| [`8ca92910`](https://github.com/nix-community/poetry2nix/commit/8ca929109d976f02f3d3a16afa0da7e9b193e9f1) | `fetchFromPypi: Fix cross`                                                                                |
| [`30e1dc36`](https://github.com/nix-community/poetry2nix/commit/30e1dc364cd9bc330e075d4245969ba497ab20ec) | `overrides.cffi: Fix cross`                                                                               |
| [`ba1107f4`](https://github.com/nix-community/poetry2nix/commit/ba1107f46b39669f35f01ae6b5a71c01896e38c5) | `overrides.pysqlite: Fix cross`                                                                           |
| [`42a24320`](https://github.com/nix-community/poetry2nix/commit/42a24320d4e8f63415adabf36e51030e00f11290) | `Update LICENSE years`                                                                                    |
| [`2834cd7a`](https://github.com/nix-community/poetry2nix/commit/2834cd7a53facac000108b4eb7278f0529751d27) | `overrides: add systemd-python`                                                                           |
| [`9b3f728d`](https://github.com/nix-community/poetry2nix/commit/9b3f728de6797819c5212d81592c0fcb4df4c0df) | `overrides: add tortoise-orm + deps`                                                                      |
| [`9b5fba1b`](https://github.com/nix-community/poetry2nix/commit/9b5fba1b7170147b054af0d627860ebe92ed5f5b) | `Fix cross compilation and add cross test`                                                                |
| [`230e4fbb`](https://github.com/nix-community/poetry2nix/commit/230e4fbb483d4ef42c82288a80a74f54bfb02ee0) | `Remove __isBootstrap hack`                                                                               |
| [`48aeba58`](https://github.com/nix-community/poetry2nix/commit/48aeba5812f021d79b88dd41a372e889b663a29b) | `overrides.matplotlib: old.passthru -> old.passthru.args`                                                 |
| [`d214b369`](https://github.com/nix-community/poetry2nix/commit/d214b36911d854f0982ea2f6beef645a97e18fe6) | `Inherit test cases from nixpkgs`                                                                         |
| [`eedd4177`](https://github.com/nix-community/poetry2nix/commit/eedd417712fe6e0a739297a4ee83e405e88e8f9e) | `Bump nixpkgs`                                                                                            |
| [`ff4c1b90`](https://github.com/nix-community/poetry2nix/commit/ff4c1b906878e0e433a3ef123c5600fc0d340716) | `Fix file deps test`                                                                                      |
| [`cacab991`](https://github.com/nix-community/poetry2nix/commit/cacab9910123d7f99fae145eb2fc1449aee7f7b7) | `overrides: Create addPbr abstraction`                                                                    |
| [`fbc86b40`](https://github.com/nix-community/poetry2nix/commit/fbc86b40d498472fbb5f3b16a08e76564a79a3b9) | `overrides: Create addPoetry abstraction`                                                                 |
| [`71f665c5`](https://github.com/nix-community/poetry2nix/commit/71f665c5bfacff22d11e0ca700a62327be54379c) | `overrides: Create addFlit abstraction`                                                                   |
| [`8be11cbe`](https://github.com/nix-community/poetry2nix/commit/8be11cbe8f72d30e30655b751efbadec0655dd14) | `Remove dontPreferSetupPy & don't remove pyproject.toml ever`                                             |
| [`8e1eef37`](https://github.com/nix-community/poetry2nix/commit/8e1eef3751764a48420048b74702ce47496f7e56) | ``fetchGit: use `allRefs` only when it is needed``                                                        |
| [`5c06704d`](https://github.com/nix-community/poetry2nix/commit/5c06704d4584cbd17d66c214447d313a896811a2) | `fetchGit: work-around bug in Nix 2.4`                                                                    |
| [`504dc068`](https://github.com/nix-community/poetry2nix/commit/504dc068bbf0bc6e9e753be47f30ff665311468c) | `Add overlay that disables checks for packages inherited from nixpkgs`                                    |
| [`01ae862d`](https://github.com/nix-community/poetry2nix/commit/01ae862d0937bc1c6694ec7f2f93096f26d0a561) | `overrides.pyparsing: Prevent infinite recursion by disabling tests`                                      |
| [`390173bc`](https://github.com/nix-community/poetry2nix/commit/390173bce21aa5eaa65ea7171d75a75382e964f5) | `fix typo in overrides: enableTk -> enableGtk3`                                                           |
| [`601609e8`](https://github.com/nix-community/poetry2nix/commit/601609e83be35bbab56af633836edb9d624dcfbf) | ` overrides.pymssql: add override`                                                                        |
| [`bdecd74f`](https://github.com/nix-community/poetry2nix/commit/bdecd74f6e8534783594b086f54131713519159b) | `overrides.pyrfr: add override`                                                                           |
| [`c5d345cb`](https://github.com/nix-community/poetry2nix/commit/c5d345cb064e5b3ddb15fd8684581cd68b7d63a8) | `overrides.flatbuffers: add override`                                                                     |
| [`31fde289`](https://github.com/nix-community/poetry2nix/commit/31fde2890a2a083913491c24661cef1da721fdd8) | `Cymem needs Cython`                                                                                      |
| [`a71ffbe7`](https://github.com/nix-community/poetry2nix/commit/a71ffbe7c537fdaeb18904294fd2b3a1e0497492) | `Remove rec from template`                                                                                |
| [`f07f5090`](https://github.com/nix-community/poetry2nix/commit/f07f50900430361fa023b5edd3e96b001822aac0) | `Bump version to 1.26.0`                                                                                  |
| [`f95121b8`](https://github.com/nix-community/poetry2nix/commit/f95121b8847d453dc6bd2c744b77a4ca9c8691a7) | `Add CI job for black formatting`                                                                         |
| [`7a7dcbe2`](https://github.com/nix-community/poetry2nix/commit/7a7dcbe2e16862629de17f098b96af38cb7e9dbc) | `Add CI job for Python2 compat checks`                                                                    |
| [`f46e65a0`](https://github.com/nix-community/poetry2nix/commit/f46e65a006b46713d5b99e511bbda6fa4cec5174) | `Fix python2 compat issues in fetch_from_legacy.py`                                                       |
| [`b8d3545e`](https://github.com/nix-community/poetry2nix/commit/b8d3545eba652ebf885cb4211239fe15e3a4da65) | `Add tooling to detect Python2 syntax errors`                                                             |
| [`8078110a`](https://github.com/nix-community/poetry2nix/commit/8078110a7f158087add0720f629e205c94865a46) | `Reformat all Python code using Black`                                                                    |
| [`b4d2477b`](https://github.com/nix-community/poetry2nix/commit/b4d2477b1f2cc8142198e959a045af71c6df71e8) | `Add a basic python environment for tooling to nix-shell`                                                 |
| [`d26cd8d7`](https://github.com/nix-community/poetry2nix/commit/d26cd8d7c5264e8685c2f8351a11bd22313fd998) | `fix: Only set ensure_ascii to False for Python >= 3`                                                     |
| [`dc8b983f`](https://github.com/nix-community/poetry2nix/commit/dc8b983f3f8e319473a19fae7be66d1a4f296527) | `Bump version to 1.25.0`                                                                                  |
| [`115a77b9`](https://github.com/nix-community/poetry2nix/commit/115a77b97e49cfaf2ac686c28fb539ff4cb7da26) | `overrides.wcwidth: Add override`                                                                         |
| [`ddea3060`](https://github.com/nix-community/poetry2nix/commit/ddea3060818f065c4bd592883ad0805db9044122) | `overrides.pysqlite: Add override`                                                                        |
| [`08c77c50`](https://github.com/nix-community/poetry2nix/commit/08c77c5078a36fac7135a9f8e10949563a3d2377) | `overrides.prettytable: Add override`                                                                     |
| [`9cb97ec5`](https://github.com/nix-community/poetry2nix/commit/9cb97ec589dd6587b082008ab8bcfa890214eea5) | `overrides.backports.functools-lru-cache: Add override`                                                   |
| [`59a1fef4`](https://github.com/nix-community/poetry2nix/commit/59a1fef4378d061471249245c27e61962bce075d) | `overrides: add scikit-image`                                                                             |
| [`91301410`](https://github.com/nix-community/poetry2nix/commit/91301410ce6b8479e4b11b50dcbc6ad141618224) | `overrides: tables: fix HDF5_DIR`                                                                         |
| [`48c228ac`](https://github.com/nix-community/poetry2nix/commit/48c228ac63d81f823cf1d7061eb8c6db9125cb47) | `The package URL is relative to the index URL`                                                            |
| [`6b063a31`](https://github.com/nix-community/poetry2nix/commit/6b063a31bc8fea6c1d9fdc47e9078772b0ba283b) | `overrides: Add fastapi override`                                                                         |
| [`6e5bdfb5`](https://github.com/nix-community/poetry2nix/commit/6e5bdfb5b1f31f6e00ff249ead226767466134c7) | `tests: Add test for IFD projectDir`                                                                      |
| [`18975821`](https://github.com/nix-community/poetry2nix/commit/189758214f5bfbec6ed2f083910c4bee0158d30a) | `overrides: remove problematic moto override`                                                             |
| [`fd9d782a`](https://github.com/nix-community/poetry2nix/commit/fd9d782a97b959afbbf47f5800261112f18ada9e) | `overrides: fix opencv-contrib-python the same way as opencv-python`                                      |
| [`a8a88890`](https://github.com/nix-community/poetry2nix/commit/a8a88890095bdfe0c3e0fa355eaf20836c0be4a6) | `overrides: Add bjoern override`                                                                          |
| [`5a8fb13c`](https://github.com/nix-community/poetry2nix/commit/5a8fb13cb1437e3669300891aedaf5fa70833f50) | `make wheel selection more sophisticated for m1 macs (#489)`                                              |
| [`c9fa77c7`](https://github.com/nix-community/poetry2nix/commit/c9fa77c72c4ee62a6d28c4993b8d875c08551a57) | `Adds pbr to requests-mock.propagatedInputs`                                                              |
| [`a97a37d0`](https://github.com/nix-community/poetry2nix/commit/a97a37d0b0bba33f8c0f4e572733219e48984e6b) | `Add table of contents to readme`                                                                         |
| [`9746602f`](https://github.com/nix-community/poetry2nix/commit/9746602f79b19878940be7b0ca3458f1aad640dc) | `Add a section for how to guides`                                                                         |
| [`604e4a4d`](https://github.com/nix-community/poetry2nix/commit/604e4a4dcf1a28fc2e0e8dc3d77c89a0ee714fcc) | `Create an acknowledgements section in the README`                                                        |
| [`2ce16fd8`](https://github.com/nix-community/poetry2nix/commit/2ce16fd82251c5c4c39b884ad15c62b28c6a7ef2) | `README: Document new editablePackageSources behaviour where develop=true`                                |
| [`97acfb6a`](https://github.com/nix-community/poetry2nix/commit/97acfb6aa073af95199db37a80cd141a673a1b59) | `Allow unsetting editable package sources by explicitly setting them to null`                             |
| [`e74bb4c3`](https://github.com/nix-community/poetry2nix/commit/e74bb4c3f52e3682694a6ae422de97db1f3aeaa9) | `Add path dependencies where develop=true as editable packages by default`                                |
| [`de898ab3`](https://github.com/nix-community/poetry2nix/commit/de898ab3fb9f28e0310351b2556b70899885df1f) | `overrides.importlib-metadata: Don't substituteInPlace for wheel package`                                 |
| [`2afe81f9`](https://github.com/nix-community/poetry2nix/commit/2afe81f902bcc89098d38ce2654aa512bf306efc) | `overrides.pytezos: Fix typo in override`                                                                 |
| [`ecaf9f13`](https://github.com/nix-community/poetry2nix/commit/ecaf9f13227ed356247a7b12fd10e74d41a58aa4) | `overrides: Add pytaglib override`                                                                        |
| [`b8f1d2d3`](https://github.com/nix-community/poetry2nix/commit/b8f1d2d3a384198e93a6cf03ee9775c0efc63d9a) | `overrides: Fix opencv-python`                                                                            |
| [`3a9ac250`](https://github.com/nix-community/poetry2nix/commit/3a9ac250e2ad364e92685212bf229be2f2adbf07) | `Prevent editable package from being built when in nix-shell environment`                                 |
| [`85bb626d`](https://github.com/nix-community/poetry2nix/commit/85bb626d839b462a60040dc3d8afe41535d1b03b) | `Create a dummy null package for the current project in case any dependencies depend on the root project` |
| [`9e9bcb70`](https://github.com/nix-community/poetry2nix/commit/9e9bcb70d2d3cbf7e45945ef26532cfdc4b7fc18) | `Add dependabot configuration to update Poetry`                                                           |
| [`c47ff252`](https://github.com/nix-community/poetry2nix/commit/c47ff252c153b3af724990abedf90074cbfd3396) | `README: fix shell example syntax`                                                                        |
| [`f3f70444`](https://github.com/nix-community/poetry2nix/commit/f3f70444b7ec8dfbb1867d8fa99c6cff1fb7f139) | `Don't filter sources where the projectDir is the output of a derivation`                                 |
| [`a9a6bd10`](https://github.com/nix-community/poetry2nix/commit/a9a6bd10e32f80bdd2794796310e444d1db569d5) | `overrides: Add pantalaimon override`                                                                     |
| [`b19f40cc`](https://github.com/nix-community/poetry2nix/commit/b19f40ccac28b4a2a2884879beab5a52c96fa535) | `overrides: Add override to build python-olm`                                                             |
| [`05e7fee4`](https://github.com/nix-community/poetry2nix/commit/05e7fee42cb209ab9ca014fae58d0ba94ffe3901) | `overrides: Add override to build dbus-python`                                                            |
| [`bb7e9777`](https://github.com/nix-community/poetry2nix/commit/bb7e977729160e7a1727f4815ee9c01d60b0a796) | `ci: remove jq formatting`                                                                                |
| [`e303e801`](https://github.com/nix-community/poetry2nix/commit/e303e801c917137aed7c167cffd4f573c2f86a96) | `ci: bump to install cachix action v16`                                                                   |
| [`5303a366`](https://github.com/nix-community/poetry2nix/commit/5303a36635500db7e85cfd1a153b81e2ede21715) | `ci: use jq to construct builds matrix`                                                                   |
| [`cf2dd105`](https://github.com/nix-community/poetry2nix/commit/cf2dd105cf5a169cec059f11f9ee79742228cb9e) | `overrides: add pyudev`                                                                                   |
| [`7dbea94e`](https://github.com/nix-community/poetry2nix/commit/7dbea94eec14ffae109ed3fb740608e1502a989a) | `overrides: add icecream`                                                                                 |
| [`6626c042`](https://github.com/nix-community/poetry2nix/commit/6626c0425a2912496307728969326d0b5a7ea378) | `fix: set ensure_ascii to False because utf8 is legit`                                                    |
| [`2fde8725`](https://github.com/nix-community/poetry2nix/commit/2fde8725f6d0318412b76ee1bf905052dd507a1d) | `test: add failing aiopath test`                                                                          |
| [`22adc787`](https://github.com/nix-community/poetry2nix/commit/22adc787cb7a73013b8a1faab144e7ce445e7846) | `style: nixpkgs-fmt`                                                                                      |
| [`261d1d5b`](https://github.com/nix-community/poetry2nix/commit/261d1d5b2291669feba7400b2a759bc5447d12d5) | `fix: remove buildInput dependency on poetry`                                                             |
| [`4a13d29a`](https://github.com/nix-community/poetry2nix/commit/4a13d29ad291065efd4430b03cd1aaf851def2ff) | `Bump version to 1.24.1`                                                                                  |
| [`966c741c`](https://github.com/nix-community/poetry2nix/commit/966c741cc037bc7d346c597f7c6e99da7c22bd19) | `cryptography: Use correct version numbers in hash lookups`                                               |
| [`8f07b30a`](https://github.com/nix-community/poetry2nix/commit/8f07b30add64e2d560fd54f7fbc864431f66108e) | `Bump version to 1.24.0`                                                                                  |
| [`e85a2fd1`](https://github.com/nix-community/poetry2nix/commit/e85a2fd17e642ad76758cd7ad0e2b2dad25c9a9e) | `Add about section to issue template`                                                                     |
| [`3eb96f27`](https://github.com/nix-community/poetry2nix/commit/3eb96f27dd5d4f1c8c5321e354d56a81c1fecf82) | `Add a github issue template`                                                                             |
| [`0985711b`](https://github.com/nix-community/poetry2nix/commit/0985711b0bd0eea97432036feee6b22c59da8edc) | `mkPoetryEnv: Add an extraPackages argument`                                                              |
| [`25066da9`](https://github.com/nix-community/poetry2nix/commit/25066da9111270de7ef72efec9d6f2e5fb6d6c57) | `Bump version to 1.23.0`                                                                                  |
| [`f7ab15e3`](https://github.com/nix-community/poetry2nix/commit/f7ab15e390653988bcf941790a411cabfd8527b4) | `Enable private PYPI repositories via netrc`                                                              |
| [`7f019e5c`](https://github.com/nix-community/poetry2nix/commit/7f019e5c5dd65af7096eec424db0379a21deac9c) | `tests.manylinux: Fix test`                                                                               |
| [`4574e008`](https://github.com/nix-community/poetry2nix/commit/4574e008196e58969e1e466c6c871727333cf327) | `tests.common-pkgs-2: Bump matplotlib`                                                                    |
| [`9ce2f75f`](https://github.com/nix-community/poetry2nix/commit/9ce2f75ff4063683bfd3f99a2aa4a88e824cfa1e) | `fix(overrides): add flit-core to typing-extensions`                                                      |
| [`8b6d7f7c`](https://github.com/nix-community/poetry2nix/commit/8b6d7f7c4f37ba2b2571eeae842753655dce8d9c) | `Fix operators test`                                                                                      |
| [`d5f756b8`](https://github.com/nix-community/poetry2nix/commit/d5f756b8e5273285a4b42d884b3af3e35556375b) | `Break out awscli to it's own separate test`                                                              |
| [`a0326eaf`](https://github.com/nix-community/poetry2nix/commit/a0326eafd86058eeceff6b4e6371ea95ad9e3d25) | `overrides.importlib-metadata: Explicitly pass version to setuptools`                                     |
| [`f00e9606`](https://github.com/nix-community/poetry2nix/commit/f00e96064ed3c982af5a128afac8e2b39eb2a436) | `Fix ansible-molecule test`                                                                               |
| [`2f2eba50`](https://github.com/nix-community/poetry2nix/commit/2f2eba50ea62a7c32f6752415f355eef2aca417d) | `overrides: Add selinux override`                                                                         |
| [`10dbbb74`](https://github.com/nix-community/poetry2nix/commit/10dbbb74056e0cb6b1993527dc971a40a8a82344) | `ansible-molecule: Update test dependencies`                                                              |
| [`2c63047e`](https://github.com/nix-community/poetry2nix/commit/2c63047ee161f9dd2cb51e01446df41417a9b124) | `Run nixpkgs-fmt after the nixpkgs bump`                                                                  |
| [`3be424ac`](https://github.com/nix-community/poetry2nix/commit/3be424ac55d2021cb4db225e6b82c1951a741298) | `Bump nixpkgs`                                                                                            |
| [`f46838d8`](https://github.com/nix-community/poetry2nix/commit/f46838d888c6a5e60bab944ec5d6c76e48a0304c) | `poetry: 1.1.11 -> 1.1.12`                                                                                |
| [`3f40ecc9`](https://github.com/nix-community/poetry2nix/commit/3f40ecc9511145cf75131b625a3872223f54a5c4) | `Switch testing strategy on Github Actions to one based on a dynamic matrix`                              |
| [`b7d3526c`](https://github.com/nix-community/poetry2nix/commit/b7d3526cee584af1357fb90b6966a1679287469d) | `README: Add Matrix room links`                                                                           |
| [`2f325da8`](https://github.com/nix-community/poetry2nix/commit/2f325da8ec5464d16e996ac5b8fbd8486a8e6917) | `fix: add missing runCommand`                                                                             |
| [`3cbe79b2`](https://github.com/nix-community/poetry2nix/commit/3cbe79b23e1b3d9c5f38871fdfa0b3addd4445e6) | `test: actually run the test`                                                                             |
| [`ca84288d`](https://github.com/nix-community/poetry2nix/commit/ca84288d6af0c64aa36a9c15979504eda84f885f) | `fix: use buildInputs`                                                                                    |
| [`4aaff206`](https://github.com/nix-community/poetry2nix/commit/4aaff2061461244e6c5cb8f90c707dc2eb2a6d7e) | `fix: patch jq to remove requests and depend on upstream jq`                                              |
| [`0040ef3f`](https://github.com/nix-community/poetry2nix/commit/0040ef3fc49ec68e946365d70fc3efec3280d9fd) | `fix: fix remaining truth value`                                                                          |
| [`41ef97ce`](https://github.com/nix-community/poetry2nix/commit/41ef97ce70de170ca3fdf32bc86536304bdbf220) | `fix: fix invalid truth value on darwin`                                                                  |
| [`e6ef03de`](https://github.com/nix-community/poetry2nix/commit/e6ef03de77445479195851ffc7d74799a2125343) | `build: minimize use of pkgs.arrow-cpp`                                                                   |
| [`2329db4c`](https://github.com/nix-community/poetry2nix/commit/2329db4c95f8853f13d0b2956fd51b1424689c24) | `refactor: remove _arrow-cpp from buildInputs`                                                            |
| [`92580ae5`](https://github.com/nix-community/poetry2nix/commit/92580ae5571360944179f3b02eaab5200bc99e40) | `fix: ensure that arrow-cpp isn't built twice when python3 != python`                                     |
| [`c9ee272a`](https://github.com/nix-community/poetry2nix/commit/c9ee272ab0e45845d3c1fca2656256c11ffa19ab) | `!fixup`                                                                                                  |
| [`12c23203`](https://github.com/nix-community/poetry2nix/commit/12c232030c92f6a2a0ce0026ad0ca391273b3045) | `overrides: matplotlib: use MPLSETUPCFG`                                                                  |
| [`aaf236d1`](https://github.com/nix-community/poetry2nix/commit/aaf236d167de5775fab1ca375cf7d6366ab2fae2) | `overrides: cryptography: fix cargo hash for versions >= 3.6.1`                                           |
| [`80f6c446`](https://github.com/nix-community/poetry2nix/commit/80f6c446fc09d626d7dcfd8623ccaa8c7b983500) | `overrides: argon2-cffi: fix for version >= 21.2.0`                                                       |
| [`58ef019d`](https://github.com/nix-community/poetry2nix/commit/58ef019d39aa12b05bba68936b57331a1892dc66) | `overrides: scipy: fix for version >= 1.7.0`                                                              |
| [`3def814c`](https://github.com/nix-community/poetry2nix/commit/3def814c0a31a4edb9dc1333838e02b2efa6fac3) | `overrides: wtforms: add`                                                                                 |
| [`64da99c7`](https://github.com/nix-community/poetry2nix/commit/64da99c770026a517521d690ea21010450b1d781) | `overrides: matplotlib: fix for version >= 3.5.0`                                                         |
| [`1c5ee0df`](https://github.com/nix-community/poetry2nix/commit/1c5ee0df4350c4834ee07461576a11043617da2c) | `add absl-py as tensorboard dependency`                                                                   |
| [`42b1e673`](https://github.com/nix-community/poetry2nix/commit/42b1e673aa5a9c9236a86ae93d100ddcaf997108) | `Include the trailing slash in legacy index URL`                                                          |
| [`62b1ec8c`](https://github.com/nix-community/poetry2nix/commit/62b1ec8cc9ab9e6be1c8cdb7994f2402bb932309) | `Update attribution and copyright to reflect Tweag's support`                                             |
| [`27b4c678`](https://github.com/nix-community/poetry2nix/commit/27b4c6784286a1ee0ca7571126d2d9eaa3878a2b) | `overrides: add kerberos`                                                                                 |
| [`63c1cf08`](https://github.com/nix-community/poetry2nix/commit/63c1cf0822e5eba027b1206cbd56e3c541d15967) | `overrides: add paramiko`                                                                                 |
| [`c533b2ed`](https://github.com/nix-community/poetry2nix/commit/c533b2edfc9a2fecc4b4d3a224fc2da87d42e6d0) | `overrides: add httplib2`                                                                                 |
| [`228fbc5b`](https://github.com/nix-community/poetry2nix/commit/228fbc5b02bd5d90002e40103e4120a96144ae91) | `overrides: add cyclonedx-python-lib`                                                                     |
| [`e17c4960`](https://github.com/nix-community/poetry2nix/commit/e17c4960b24c9b0cec09354dc17d32ac94152a66) | `overrides: cryptography: fix cargo hash for versions >= 3.6.0`                                           |
| [`e093c9c3`](https://github.com/nix-community/poetry2nix/commit/e093c9c326bd86bd0649e226f01b8f5d8a6d159d) | `importlib-resources: Don't remove pyproject.toml`                                                        |
| [`95980c5e`](https://github.com/nix-community/poetry2nix/commit/95980c5e403ddc072f20f2e154dd02185413353d) | `Revert "feat: Re-enable mypyc from version 0.910"`                                                       |
| [`f84d464f`](https://github.com/nix-community/poetry2nix/commit/f84d464f41d2210da2569b05c7281c19be23072e) | `Bump version to 1.22.0`                                                                                  |
| [`d4b77f40`](https://github.com/nix-community/poetry2nix/commit/d4b77f40218e9699b8f0820777b63c6ece337970) | `poetry: 1.1.10 -> 1.1.11`                                                                                |
| [`be767987`](https://github.com/nix-community/poetry2nix/commit/be76798783f8778206f37ce112ddc9e618ba0f08) | `Fix building cloudflare`                                                                                 |
| [`81d9e93b`](https://github.com/nix-community/poetry2nix/commit/81d9e93b33cb6fffd956160d73a5f036edcd7339) | `docs(pyproject-without-special-deps.py): fix help string`                                                |
| [`b95fe190`](https://github.com/nix-community/poetry2nix/commit/b95fe190ce78c99bf2c2d53014cc1ba872938d6e) | `refactor(pyproject-without-special-deps.py): use bools instead of ints`                                  |
| [`9a495722`](https://github.com/nix-community/poetry2nix/commit/9a495722efbb4186b73cdfd4f72a653197de723d) | `refactor(pyproject-without-special-deps.py): remove unused variable`                                     |
| [`7e026ee1`](https://github.com/nix-community/poetry2nix/commit/7e026ee1849a0c612058deb7ad52875ab40ea4fa) | `docs(pyproject-without-special-deps.py): clean up comment`                                               |
| [`144f884a`](https://github.com/nix-community/poetry2nix/commit/144f884a5baa0393fa322dd67653b536fdaf1012) | `poetry2nix: regen lock file`                                                                             |
| [`7191e51b`](https://github.com/nix-community/poetry2nix/commit/7191e51bd7ab46f9a45a92a033f4e7410bfc0cf9) | `common-pkgs-2: don't install argparse if >= 2.7`                                                         |
| [`47dac9d9`](https://github.com/nix-community/poetry2nix/commit/47dac9d9e4a31289cd76f86955a5b895dc341ddd) | `common-pkgs-2: lock cryptography to 3`                                                                   |
| [`5a3bfdf4`](https://github.com/nix-community/poetry2nix/commit/5a3bfdf4f932c209530f0647192aaf0e6c97b7d0) | `common-pkgs-2: remove unused comment`                                                                    |
| [`2fed7bc9`](https://github.com/nix-community/poetry2nix/commit/2fed7bc9104dd01cdb7a307d252e5a0ce906554a) | `pip: remove restriction`                                                                                 |
| [`d3be0fd8`](https://github.com/nix-community/poetry2nix/commit/d3be0fd830a1be0a3193b5a5a518e2aaee837438) | `Fix building cryptography 3.5`                                                                           |