### PR TITLE
chore(flake/flake-utils): `7e5bf392` -> `846b2ae0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1631561581,
-        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                                                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`846b2ae0`](https://github.com/numtide/flake-utils/commit/846b2ae0fc4cc943637d3d1def4454213e203cba) | `Update default.nix (#42)`                                                      |
| [`3f197dc7`](https://github.com/numtide/flake-utils/commit/3f197dc7591cc6edc83e1eb44698283c19fd28a2) | `add system map for convenience (#55)`                                          |
| [`74f7e431`](https://github.com/numtide/flake-utils/commit/74f7e4319258e287b0f9cb95426c9853b282730b) | ``eachSystem: push down `system` as far down as possible for Hydra jobs (#46)`` |
| [`ad1f7522`](https://github.com/numtide/flake-utils/commit/ad1f7522aa667e91471d8335d519fc2e2e2856e8) | `Bump cachix/install-nix-action from 15 to 16 (#49)`                            |
| [`bba5dcc8`](https://github.com/numtide/flake-utils/commit/bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4) | `Bump cachix/install-nix-action from 14 to 15 (#48)`                            |
| [`c91f3de5`](https://github.com/numtide/flake-utils/commit/c91f3de5adaf1de973b797ef7485e441a65b8935) | `eachSystem: special case hydraJobs to match hydra convention. (#45)`           |