### PR TITLE
chore(flake/nixpkgs): `e4ef597e` -> `5c9b6ab9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1633971123,
-        "narHash": "sha256-WmI4NbH1IPGFWVkuBkKoYgOnxgwSfWDgdZplJlQ93vA=",
+        "lastModified": 1643963578,
+        "narHash": "sha256-LYt6LTltbAe9qUqFKwESCKO/hd08lEHuJvRbeKMDfDQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e4ef597edfd8a0ba5f12362932fc9b1dd01a0aef",
+        "rev": "5c9b6ab9ca4e3963cf0de8f8f331a3eeb0d481aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`d67ad28f`](https://github.com/NixOS/nixpkgs/commit/d67ad28fc301305baeeb364a04f0565c5f5118c8) | `go_1_18: init at go1.18beta1`                                         |
| [`af3cd7c1`](https://github.com/NixOS/nixpkgs/commit/af3cd7c1f80738cc6ef4512cfa8d0bbfc45a88db) | `go: Fix the build in non-root sandboxes`                              |
| [`30ea86e2`](https://github.com/NixOS/nixpkgs/commit/30ea86e22dbc144583d45b43ca2ca42d6ac161dc) | `binlore: 0.1.3 -> 0.1.4 (#157234)`                                    |
| [`3f6221e0`](https://github.com/NixOS/nixpkgs/commit/3f6221e0c45f5bdab8563024c60dd2a029469025) | `python310Packages.aioconsole: 0.4.0 -> 0.4.1`                         |
| [`1b2ce9be`](https://github.com/NixOS/nixpkgs/commit/1b2ce9bed79cad9204185b426dde1a716ce28ca2) | `fcitx5-table-other: 5.0.6 -> 5.0.7`                                   |
| [`e0d4564c`](https://github.com/NixOS/nixpkgs/commit/e0d4564cd701c7f2712ed8d7f37633632a44c139) | `fcitx5-table-extra: 5.0.7 -> 5.0.8`                                   |
| [`4460596d`](https://github.com/NixOS/nixpkgs/commit/4460596db6159abb30c63b5b55c005a64cf4bab3) | `fcitx5-chinese-addons: 5.0.10 -> 5.0.11`                              |
| [`6de4ef3c`](https://github.com/NixOS/nixpkgs/commit/6de4ef3cc285a98af16bc5b7d2bc3a876b9bcfc6) | `fcitx5-rime: 5.0.10 -> 5.0.11`                                        |
| [`c1ae861a`](https://github.com/NixOS/nixpkgs/commit/c1ae861a506bbe149e2b1c2de8d34a0fa845db18) | `fcitx5-lua: 5.0.5 -> 5.0.6`                                           |
| [`650c87ca`](https://github.com/NixOS/nixpkgs/commit/650c87cab8782f37c93ee117b89a313a789322c7) | `fcitx5-configtool: 5.0.10 -> 5.0.11`                                  |
| [`b044afff`](https://github.com/NixOS/nixpkgs/commit/b044afff42d6ebf69d8e8c3a2213590abc8323cc) | `libsForQt5.fcitx5-qt: 5.0.9 -> 5.0.10`                                |
| [`af3af2df`](https://github.com/NixOS/nixpkgs/commit/af3af2df325b50bfde8f84d13077467e093751f9) | `cwltool: 3.1.20220124184855 -> 3.1.20220202173120`                    |
| [`9e9c5efa`](https://github.com/NixOS/nixpkgs/commit/9e9c5efaca3fc6bdb825799188f40a2049b2ce2b) | `vimPlugins.tup: fix ftdetect`                                         |
| [`02ba9653`](https://github.com/NixOS/nixpkgs/commit/02ba965390d959fadce70ed6f02831709958eb4c) | `kitty: 0.24.1 -> 0.24.2`                                              |
| [`1bad7be6`](https://github.com/NixOS/nixpkgs/commit/1bad7be6c6ec114355a403414f131f70b1769274) | `python3Packages.homematicip: 1.0.1 -> 1.0.2`                          |
| [`027b3fab`](https://github.com/NixOS/nixpkgs/commit/027b3fab5cb431cfba422391a9f10713eff3e024) | `python3Packages.pvo: 0.2.0 -> 0.2.1`                                  |
| [`2dba964f`](https://github.com/NixOS/nixpkgs/commit/2dba964f32cb68799dceb02a095a41e9f09b4dad) | `python3Packages.glances-api: remove stale substituteInPlace`          |
| [`0d039173`](https://github.com/NixOS/nixpkgs/commit/0d0391735c3756754c8a86bdd6d47613d0556468) | `faraday-cli: add missing dependency`                                  |
| [`63e8294f`](https://github.com/NixOS/nixpkgs/commit/63e8294fd1adf66e5f7398694bb6f6e420094afe) | `python3Packages.skodaconnect: 1.1.14 -> 1.1.17`                       |
| [`59c967ab`](https://github.com/NixOS/nixpkgs/commit/59c967ab74fd17db43c26569812cfaf38296adf6) | `python3Packages.seatconnect: 1.1.4 -> 1.1.5`                          |
| [`06b5a570`](https://github.com/NixOS/nixpkgs/commit/06b5a57024dc8f2d9f8754e9665b10b67c521043) | `python3Packages.meshtastic: 1.2.80 -> 1.2.81`                         |
| [`17f5966d`](https://github.com/NixOS/nixpkgs/commit/17f5966dc6e2981edfd546ffeb2796d4abb1a2ab) | `python3Packages.identify: 2.4.7 -> 2.4.8`                             |
| [`46e72839`](https://github.com/NixOS/nixpkgs/commit/46e728393cd7b25a8d8bb549297abedf4a7b219d) | `python3Packages.faraday-plugins: 1.5.10 -> 1.6.0`                     |
| [`be8837a2`](https://github.com/NixOS/nixpkgs/commit/be8837a25807286aa74c90b1c87cfc49486c4654) | `home-assistant: update component-packages`                            |
| [`50299ef0`](https://github.com/NixOS/nixpkgs/commit/50299ef014f201b1993f34f84dc8c51c1a3086b1) | `python3Packages.pyqvrpro: init at 0.52`                               |
| [`c9c1eed3`](https://github.com/NixOS/nixpkgs/commit/c9c1eed34e0c5777ab5ef094b9560f58b290c7a2) | `python3Packages.papis: switch to pytestCheckHook`                     |
| [`b00ecd5e`](https://github.com/NixOS/nixpkgs/commit/b00ecd5e3d4610fb61777ba7c0fe6a1da2b30cb6) | `mysides: new package for darwin (#155053)`                            |
| [`fac7eed2`](https://github.com/NixOS/nixpkgs/commit/fac7eed24230d3f8e14ff55789ac578c51f1833f) | `yt-dlp: 2022.1.21 -> 2022.2.3`                                        |
| [`9c60df4c`](https://github.com/NixOS/nixpkgs/commit/9c60df4c8de2fb316e9e798be5d1ef0970a178ec) | `python3Packages.filetype: 1.0.9 -> 1.0.10`                            |
| [`06ee2778`](https://github.com/NixOS/nixpkgs/commit/06ee2778b6cadc847ad6cab926af4359c757b98c) | `home-assistant: update component-packages`                            |
| [`23eb6d29`](https://github.com/NixOS/nixpkgs/commit/23eb6d2924720f357eeb63b526c62fd81ab96522) | `python3Packages.adax-local: init at 0.1.3`                            |
| [`357025f8`](https://github.com/NixOS/nixpkgs/commit/357025f888b7060a91d4f62fcb9bced19e65bd11) | `saml2aws: update vendorSha256`                                        |
| [`7c5b41b6`](https://github.com/NixOS/nixpkgs/commit/7c5b41b6b8c4ae24d17c7e2d29861f759a86c54f) | `victoriametrics: pin to go_1_16`                                      |
| [`cbe3e279`](https://github.com/NixOS/nixpkgs/commit/cbe3e2797a599b31a167c43cdad145a75a6cbf2f) | `open-policy-agent: pin to go_1_16`                                    |
| [`d5143d4e`](https://github.com/NixOS/nixpkgs/commit/d5143d4ef929acb540b3bc13322dfcc37c4c201f) | `reproxy: pin to go_1_16`                                              |
| [`2a4dab81`](https://github.com/NixOS/nixpkgs/commit/2a4dab81d8f216aae84532facb0c62e115a627ac) | `gocode-gomod: disable check`                                          |
| [`c8a3a567`](https://github.com/NixOS/nixpkgs/commit/c8a3a56753d1e33908b9c79ca3a7d1c2a26bdddf) | `keybase: update vendorSha256`                                         |
| [`46a658d4`](https://github.com/NixOS/nixpkgs/commit/46a658d41450e71c17143a532a36e9b69f505e85) | `vgo2nix: update vendorSha256`                                         |
| [`c76d51fc`](https://github.com/NixOS/nixpkgs/commit/c76d51fcedff5f8d68e1c3391ddf452edad1e974) | `gopls: update vendorSha256`                                           |
| [`47a89959`](https://github.com/NixOS/nixpkgs/commit/47a89959405ea0c254cf0a16b1aec0a7baecdb46) | `go, buildGoModule, buildGoPackage: default to 1.17`                   |
| [`fcb7b15b`](https://github.com/NixOS/nixpkgs/commit/fcb7b15b10ad7eb51221df5e2d93a6306f9abe9a) | `home-assistant: update component-packages`                            |
| [`277d6494`](https://github.com/NixOS/nixpkgs/commit/277d6494b24a310c2e91fa0d9b136576f682c162) | `python3Packages.aurorapy: init at 0.2.6`                              |
| [`2d8b6c7a`](https://github.com/NixOS/nixpkgs/commit/2d8b6c7a23910311fe9a0d51de766c260756ee60) | `checkov: 2.0.763 -> 2.0.787`                                          |
| [`30da1274`](https://github.com/NixOS/nixpkgs/commit/30da1274dbd90939520fe6e18499489650d06787) | `python310Packages.deezer-python: 5.0.1 -> 5.1.0`                      |
| [`f4dccd58`](https://github.com/NixOS/nixpkgs/commit/f4dccd58f4676b8363ede9e7779c7fb8352ce3b0) | `rocksdb: 6.27.3 -> 6.28.2`                                            |
| [`1ec30a90`](https://github.com/NixOS/nixpkgs/commit/1ec30a90031eaa98c691a68fa2156403af76e4e8) | `perlPackages.ConfigIniFiles: Use buildPerlPackage`                    |
| [`5a7f3100`](https://github.com/NixOS/nixpkgs/commit/5a7f3100e3ccd4269c0da5a39b7c4c14b6a33dbf) | `vaultwarden: 1.23.1 -> 1.24.0`                                        |
| [`2b35e890`](https://github.com/NixOS/nixpkgs/commit/2b35e89066064e9f6cc05546e7287f818d184019) | `python3Packages.pywlroots: 0.15.6 -> 0.15.7`                          |
| [`a699e7ce`](https://github.com/NixOS/nixpkgs/commit/a699e7ceb41ebc46798ea3222b6ab7153fef0919) | `home-assistant: update component-packages`                            |
| [`241fc63f`](https://github.com/NixOS/nixpkgs/commit/241fc63f215952427ecfd0c3989f3f965063ce89) | `python3Packages.aioaseko: init at 0.0.1`                              |
| [`5c6b8b6f`](https://github.com/NixOS/nixpkgs/commit/5c6b8b6fcfc029f8468b7a5e4038d1f7bd64fc70) | `home-assistant: update component-packages`                            |
| [`3f76c7d1`](https://github.com/NixOS/nixpkgs/commit/3f76c7d11a8bb09361f3d4c5c676a9ce35fd993c) | `python3Packages.pyaussiebb: init at 0.0.9`                            |
| [`2336118e`](https://github.com/NixOS/nixpkgs/commit/2336118ea9e33f9714efbf0c7e4927abade8cbbc) | `tcpreplay: 4.3.4 -> 4.4.0`                                            |
| [`b484b1c2`](https://github.com/NixOS/nixpkgs/commit/b484b1c2dd85bd4233296278d410d280157949af) | `stgit: 1.4 -> 1.5`                                                    |
| [`9e0cc1ce`](https://github.com/NixOS/nixpkgs/commit/9e0cc1ce07a8d40799d14b106169bb87fc1712d2) | `home-assistant: update component-packages`                            |
| [`e4a506d6`](https://github.com/NixOS/nixpkgs/commit/e4a506d6997ea653a4debb165232d8205d5cd1ab) | `python3Packages.aiooncue: init at 0.3.2`                              |
| [`cd1daa01`](https://github.com/NixOS/nixpkgs/commit/cd1daa018aa17873e0dc6df16a2b26df3595e950) | `sidplayfp: 2.2.2 -> 2.2.3`                                            |
| [`9baf6886`](https://github.com/NixOS/nixpkgs/commit/9baf6886462a2a4cd71599680802d2459f28be23) | `python310Packages.limnoria: 2022.1.1.post1 -> 2022.1.29`              |
| [`d18a68f3`](https://github.com/NixOS/nixpkgs/commit/d18a68f3e047253d89b118c99388744d72dd4ac7) | `home-assistant: update component-packages`                            |
| [`e7271045`](https://github.com/NixOS/nixpkgs/commit/e72710456d5adf5ab44f5ed9c48fc3d6a6e9a453) | `python3Packages.circuit-webhook: init at 1.0.1`                       |
| [`1a476523`](https://github.com/NixOS/nixpkgs/commit/1a476523b8a8c1ac65fb31495c49ebe231d25fac) | `home-assistant: update component-packages`                            |
| [`a4992f0e`](https://github.com/NixOS/nixpkgs/commit/a4992f0e97f374b483929ae11feb763e3cee73ca) | `python3Packages.aiowebostv: init at 0.1.2`                            |
| [`d0e8f0c9`](https://github.com/NixOS/nixpkgs/commit/d0e8f0c9513fb1b3d4358ae2f85b864e95c226ff) | `home-assistant: update component-packages`                            |
| [`2563b468`](https://github.com/NixOS/nixpkgs/commit/2563b46830c9a6e12cdd73a68f820429ea908273) | `python3Packages.rtsp-to-webrtc: init at 0.5.0`                        |
| [`61592546`](https://github.com/NixOS/nixpkgs/commit/6159254671a1e5d52afda2bc56bbdd5ef4020ff0) | `home-assistant: update component-packages`                            |
| [`4be4b4ee`](https://github.com/NixOS/nixpkgs/commit/4be4b4ee54e00ed52aee07c2502604d725e219e9) | `python3Packages.ttls: init at 1.4.2`                                  |
| [`f6068cbf`](https://github.com/NixOS/nixpkgs/commit/f6068cbf1e9a2223a0942b64018991f8191220d8) | `Revert "cups: 2.4.0 -> 2.4.1"`                                        |
| [`ecbb9e66`](https://github.com/NixOS/nixpkgs/commit/ecbb9e669d0a66d9d8297e5f7c278772dec425e3) | `home-assistant: update component-packages`                            |
| [`9edef3a2`](https://github.com/NixOS/nixpkgs/commit/9edef3a262f0ca6cff2aa80a210fcfc73fa269dc) | `azure-cli: fix azure-batch sha`                                       |
| [`4d5d012d`](https://github.com/NixOS/nixpkgs/commit/4d5d012dd4cb4402db469c784df1f9b2136fa73f) | `python310Packages.azure-batch: 11.0.0 -> 12.0.0`                      |
| [`6593e3f2`](https://github.com/NixOS/nixpkgs/commit/6593e3f2ae40e2dafb5f2793c62e08699afba188) | `python3Packages.intellifire4py: init at 0.5`                          |
| [`7cb44e1b`](https://github.com/NixOS/nixpkgs/commit/7cb44e1b8eb4163653588c4ebaaa44d578321acd) | `python310Packages.mautrix: 0.14.8 -> 0.14.10`                         |
| [`2536a4a2`](https://github.com/NixOS/nixpkgs/commit/2536a4a2d887975d9bf16c1b41171b506ec16393) | `terragrunt: 0.36.0 -> 0.36.1`                                         |
| [`3bb74c77`](https://github.com/NixOS/nixpkgs/commit/3bb74c77da6e349b33cbe551bc64fb7fd87f8b93) | `stern: 1.20.1 -> 1.21.0`                                              |
| [`01d86082`](https://github.com/NixOS/nixpkgs/commit/01d86082da7ab8ad86a8cf3742a09f6b5a2ae5f0) | `cups: 2.4.0 -> 2.4.1`                                                 |
| [`a5b8447b`](https://github.com/NixOS/nixpkgs/commit/a5b8447bbd6989c443fb43af7b933347f1da4e4c) | `soft-serve: 0.1.2 -> 0.1.3`                                           |
| [`9c6d41d9`](https://github.com/NixOS/nixpkgs/commit/9c6d41d9f80253206ef84bf5b9ac57f35c36e258) | `saml2aws: 2.33.0 -> 2.34.0`                                           |
| [`38ce6b3c`](https://github.com/NixOS/nixpkgs/commit/38ce6b3ccbd2b24aaf3cf425bf82f60f89ffb9ad) | `python310Packages.awscrt: 0.13.0 -> 0.13.1`                           |
| [`13e6570b`](https://github.com/NixOS/nixpkgs/commit/13e6570b1ee2a71399d9f2ab66ad85a12ae4fb0e) | `python310Packages.xml2rfc: 3.12.0 -> 3.12.1`                          |
| [`349740ca`](https://github.com/NixOS/nixpkgs/commit/349740ca4f9c36ce8cacb6100798447b59f45728) | `python310Packages.django_classytags: 3.0.0 -> 3.0.1`                  |
| [`8c4e1859`](https://github.com/NixOS/nixpkgs/commit/8c4e18593f4401594b1eac9c45e182ee1a68f2c8) | `python310Packages.pytrends: 4.7.3 -> 4.8.0`                           |
| [`e7982e91`](https://github.com/NixOS/nixpkgs/commit/e7982e91d857e33effff6dbaafd2f89a6f2c258f) | `python310Packages.pyshp: 2.1.3 -> 2.2.0`                              |
| [`44a9603a`](https://github.com/NixOS/nixpkgs/commit/44a9603ae7e6967e21b2e857652c610a4fb0fcf8) | `python310Packages.dropbox: 11.26.0 -> 11.27.0`                        |
| [`9f7b4618`](https://github.com/NixOS/nixpkgs/commit/9f7b46184462c86cc4c8a7c5001554db9c1cc496) | `python310Packages.googlemaps: 4.5.3 -> 4.6.0`                         |
| [`750f6312`](https://github.com/NixOS/nixpkgs/commit/750f63123a89145a93f09d82a2b07d1d7ef57338) | `python310Packages.types-urllib3: 1.26.8 -> 1.26.9`                    |
| [`f52a615a`](https://github.com/NixOS/nixpkgs/commit/f52a615afbc381cd06f7702b166727ab21a55ddc) | `python310Packages.snowflake-connector-python: 2.7.3 -> 2.7.4`         |
| [`e5213f40`](https://github.com/NixOS/nixpkgs/commit/e5213f40dbd5a5ce22a13b5a0e130310e43ece76) | `cups: Add passthru printing test`                                     |
| [`0ccdb13c`](https://github.com/NixOS/nixpkgs/commit/0ccdb13c05e26b5e1bbaefea285b9500c8505284) | `numberstation: 1.0.1 -> 1.1.0`                                        |
| [`a751e798`](https://github.com/NixOS/nixpkgs/commit/a751e798041053c226c734c707c2e6dc0fc76c66) | `openai: 0.13.0 -> 0.14.0`                                             |
| [`e796d111`](https://github.com/NixOS/nixpkgs/commit/e796d111569b76db93c4632bdc156a8f3a3c0797) | `python310Packages.pyface: 7.3.0 -> 7.4.0`                             |
| [`2d011298`](https://github.com/NixOS/nixpkgs/commit/2d011298dc4cfbb03279d80db33ea44a568325c0) | `python310Packages.python-telegram-bot: 13.10 -> 13.11`                |
| [`743d0116`](https://github.com/NixOS/nixpkgs/commit/743d01161616720fb668eae2ea7199edb37af9e3) | `hivemind: 1.0.6 -> 1.1.0 (#157994)`                                   |
| [`829196bf`](https://github.com/NixOS/nixpkgs/commit/829196bfbe0d41f636d80ee87a85bfa384dec1f3) | `ruffle: 2021-09-17 -> 2022-02-02 (#157974)`                           |
| [`b8f6ce15`](https://github.com/NixOS/nixpkgs/commit/b8f6ce151a2882309a11b48f29158fea12e44da5) | `gocyclo: 2015-02-08 -> 0.4.0 (#157227)`                               |
| [`3504c23b`](https://github.com/NixOS/nixpkgs/commit/3504c23b789d898b647cfea964179febed81b1b7) | `rpm: fix build for darwin aarch64`                                    |
| [`af577101`](https://github.com/NixOS/nixpkgs/commit/af57710166671dbde702114ca6cbe9f72e438219) | `libxc: 5.2.0 -> 5.2.2`                                                |
| [`db6600c3`](https://github.com/NixOS/nixpkgs/commit/db6600c30147ad6bde737e645db4219d4ee80c0c) | `mastodon: 3.4.5 -> 3.4.6`                                             |
| [`0ebdfab8`](https://github.com/NixOS/nixpkgs/commit/0ebdfab88bb1d794d854e2e2ec0ed45ec1c252f3) | `lean: 3.38.0 -> 3.39.0`                                               |
| [`f53b32b0`](https://github.com/NixOS/nixpkgs/commit/f53b32b059dd42ca873a72b9d1dd87dc7b28e140) | `python3Packages.geometric: init at 0.9.7.2`                           |
| [`778b1f8b`](https://github.com/NixOS/nixpkgs/commit/778b1f8b4f7ac8011e15a1dafb6d90c753ef4750) | `sage: no longer assume fonttools emits deprecation warnings`          |
| [`b8305074`](https://github.com/NixOS/nixpkgs/commit/b8305074253b16fe0d98778491ee08f81f100281) | `nixos/self-deploy: consume self-deploy's startAt attribute`           |
| [`06d0bc55`](https://github.com/NixOS/nixpkgs/commit/06d0bc55bf1f210499326babc6ce33d1548fb6e0) | `gmid: 1.7.5 → 1.8`                                                    |
| [`6daff249`](https://github.com/NixOS/nixpkgs/commit/6daff24989d8142c4dd1e54d7e365d915d8203c3) | `out_of_date_package_report.md: fix typo`                              |
| [`c559795c`](https://github.com/NixOS/nixpkgs/commit/c559795c0fd8c784f890520f1a4949b85bcbcf69) | `duckstation: 0.pre+date=2021-12-16 -> 0.pre+date=2022-01-18`          |
| [`e0a91196`](https://github.com/NixOS/nixpkgs/commit/e0a91196b5a9279ecd924d77287ade72aba536d3) | `trezor-suite: 21.12.2 -> 22.1.1`                                      |
| [`c835c1ff`](https://github.com/NixOS/nixpkgs/commit/c835c1ff884a32cdfa2a5d0ebc61746ed2b199a1) | `fcitx5-unikey: 5.0.7 -> 5.0.8`                                        |
| [`e1c16048`](https://github.com/NixOS/nixpkgs/commit/e1c16048e51b021a341e36a1c3a05cffe669f630) | `fcitx5-gtk: 5.0.11 -> 5.0.12`                                         |
| [`110c2062`](https://github.com/NixOS/nixpkgs/commit/110c2062f5667b98903a408de43ebb2b253c93ff) | `fcitx5: 5.0.12 -> 5.0.14`                                             |
| [`5320a03f`](https://github.com/NixOS/nixpkgs/commit/5320a03fdc39753784de42b8b4af9ef4110f9f4f) | `crystal: remove broken crystal2nix attribute`                         |
| [`37e39b38`](https://github.com/NixOS/nixpkgs/commit/37e39b389795ea9456ff60f6934f14bb61ff754d) | `crystal_1_2: add support for aarch64-darwin`                          |
| [`7acca657`](https://github.com/NixOS/nixpkgs/commit/7acca6575875b60e7bd0ab4a1fd6bbc099522f56) | `chatty: 0.4.0 -> 0.6.0`                                               |
| [`2292af28`](https://github.com/NixOS/nixpkgs/commit/2292af28f1ce1e27c433c59b77153628587141a3) | `python310Packages.google-cloud-logging: 2.7.0 -> 3.0.0`               |
| [`7fbf10b5`](https://github.com/NixOS/nixpkgs/commit/7fbf10b51942ff6e01225849726b4c59efa391e5) | `buf: 1.0.0-rc11 -> 1.0.0-rc12`                                        |
| [`dc5859ef`](https://github.com/NixOS/nixpkgs/commit/dc5859ef7a75e79cfb3cc0084ed59738a018bb17) | `nixos/tests/k3s: remove stale test reference`                         |
| [`5453d969`](https://github.com/NixOS/nixpkgs/commit/5453d9693bf1067d441370b1d12f0c474936b982) | `python310Packages.repoze_who: 2.4 -> 2.4.1`                           |
| [`f3e4bb24`](https://github.com/NixOS/nixpkgs/commit/f3e4bb247f036b00df63364e9adb26743b85399a) | `timetagger: 22.1.4 -> 22.2.1`                                         |
| [`4f393135`](https://github.com/NixOS/nixpkgs/commit/4f39313552307af3130a3cabee8d8967004a7a5f) | `vscode-extensions.alygin.vscode-tlaplus: 1.5.3 -> 1.5.4`              |
| [`9a81c40c`](https://github.com/NixOS/nixpkgs/commit/9a81c40ce60b92068b7845257696919f09fb149f) | `vscode-extensions.timonwong.shellcheck: 0.14.4 -> 0.18.4`             |
| [`f6d1a3a2`](https://github.com/NixOS/nixpkgs/commit/f6d1a3a25c01f4b3c2e4956ab1d16d5aa6d85630) | `vscode-extensions.zhuangtongfa.material-theme: 3.9.12 -> 3.13.17`     |
| [`09d59243`](https://github.com/NixOS/nixpkgs/commit/09d592432581ba5bd2725b604b5490bea5fa460f) | `vscode-extensions.jnoortheen.nix-ide: 0.1.18 -> 0.1.19`               |
| [`16dba82a`](https://github.com/NixOS/nixpkgs/commit/16dba82a7ae3ea82e4e06c1f9e2319f7ee99c1c0) | `vscode-extensions.graphql.vscode-graphql: 0.3.13 -> 0.3.50`           |
| [`c45cab55`](https://github.com/NixOS/nixpkgs/commit/c45cab552ac5695a3ac682e4d12c52f47ba76880) | `vscode-extensions.mishkinf.goto-next-previous-member: 0.0.5 -> 0.0.6` |
| [`bd528715`](https://github.com/NixOS/nixpkgs/commit/bd528715d8f004940ded9351e32c24698bde79f5) | `vscode-extensions.codezombiech.gitignore: 0.6.0 -> 0.7.0`             |
| [`c23128e6`](https://github.com/NixOS/nixpkgs/commit/c23128e6aece4f914e520ea8d76311def648fe57) | `vscode-extensions.github.copilot: 1.7.4421 -> 1.7.4812`               |
| [`7a72dafb`](https://github.com/NixOS/nixpkgs/commit/7a72dafbc10fa421fc07cbaa2af076ba12b3ed78) | `vscode-extensions.edonet.vscode-command-runner: 0.0.116 -> 0.0.122`   |
| [`0272dc8a`](https://github.com/NixOS/nixpkgs/commit/0272dc8a6bcfc3989b740de0465ae3521d0e5b07) | `vscode-extensions.disneystreaming.smithy: init at 0.0.2`              |
| [`ed89d9af`](https://github.com/NixOS/nixpkgs/commit/ed89d9af8c30ab1255371e344b1c8d684dc76617) | `vscode-extensions.Arjun.swagger-viewer: init at 3.1.2`                |
| [`e1808192`](https://github.com/NixOS/nixpkgs/commit/e18081929d8e1767bab8849136102c1b60b367b2) | `vscode-extensions.humao.rest-client: init at 0.24.6`                  |
| [`6ff4ad16`](https://github.com/NixOS/nixpkgs/commit/6ff4ad160f2b58506a76c6ca86fd4ca1825461cc) | `vscode-extensions.benfradet.vscode-unison: init at 0.3.0`             |
| [`08c04a59`](https://github.com/NixOS/nixpkgs/commit/08c04a59a9fb380d2f57debec74fca735a929283) | `vscode-extensions.silvenon.mdx: init at 0.1.0`                        |
| [`65256eda`](https://github.com/NixOS/nixpkgs/commit/65256edaa8c552018276c90e35434f9cab526d2a) | `vscode-extensions.baccata.scaladex-search: 0.0.1 -> 0.2.0`            |
| [`ee99db6c`](https://github.com/NixOS/nixpkgs/commit/ee99db6c3fc1f5d84d32e54be380865a01ff0962) | `vscode-extensions.scalameta.metals: 1.12.0 -> 1.12.18`                |
| [`702a93b1`](https://github.com/NixOS/nixpkgs/commit/702a93b15ebcdb592b7110bbb20aad3f6592997c) | `vscode-extensions.kubukoz.nickel-syntax: init at 0.0.1`               |
| [`df8f06c8`](https://github.com/NixOS/nixpkgs/commit/df8f06c8e58dc0f643c3238ab3ecee223afec4ea) | `release-small.nix: cleanup`                                           |
| [`2571561c`](https://github.com/NixOS/nixpkgs/commit/2571561c50fa86155fb153da0c52005c1a4d5dfe) | `element-desktop: update electron_13 -> electron_15`                   |
| [`cd17b35b`](https://github.com/NixOS/nixpkgs/commit/cd17b35b1c77e4d5102d09895f975778cad3c10a) | `electron_13: 13.6.8 -> 13.6.9`                                        |
| [`c52e8567`](https://github.com/NixOS/nixpkgs/commit/c52e85672b425130b1d76ba8f08abeac02458408) | `qemu: remove broker wrapper script`                                   |
| [`8ab663aa`](https://github.com/NixOS/nixpkgs/commit/8ab663aaa5fbe8ae90931cb64d2dbd64dfac5c0c) | `brave: 1.34.81 -> 1.35.100`                                           |
| [`7b5b5adf`](https://github.com/NixOS/nixpkgs/commit/7b5b5adfcc80164e27031646c99ce87d0fd024aa) | `sentry-native: 0.4.13 -> 0.4.14`                                      |
| [`6d957f73`](https://github.com/NixOS/nixpkgs/commit/6d957f73abd92d193a55b09660c2d2b39bc87e33) | `vowpal-wabbit: 8.11.0 -> 9.0.1`                                       |
| [`ebd52e49`](https://github.com/NixOS/nixpkgs/commit/ebd52e4984e44283adbc2746274b3936983cb5d7) | `python310Packages.vowpalwabbit: 9.0.0 -> 9.0.1`                       |
| [`6536222c`](https://github.com/NixOS/nixpkgs/commit/6536222c0051bcfe9660f83af74d187dcd33a41a) | `python3Packages.pywlroots: 0.15.4 -> 0.15.6`                          |
| [`5d6e9b3d`](https://github.com/NixOS/nixpkgs/commit/5d6e9b3d53734b1956ea35f4b8280e95a064bb09) | `python3Packages.pubnub: 6.0.0 -> 6.0.1`                               |
| [`a63b5c9e`](https://github.com/NixOS/nixpkgs/commit/a63b5c9e5cbc8bbee514eff72acffacde530942d) | `clickhouse-cli: 0.3.7 -> 0.3.8`                                       |
| [`6267a995`](https://github.com/NixOS/nixpkgs/commit/6267a995ec2abd5c4a9f977851e54ffaa7080977) | `nixos/home-assistant: drop --runner flag`                             |
| [`5b8e263c`](https://github.com/NixOS/nixpkgs/commit/5b8e263c9034522effe49a0eb4efbedd96e8815d) | `python3Packages.eebrightbox: drop`                                    |
| [`225fd5c8`](https://github.com/NixOS/nixpkgs/commit/225fd5c892a21ef1d75979aee4c41cd10abb3c8b) | `python3Packages.glean-sdk: 42.2.0 -> 43.0.2`                          |
| [`93a6cd0f`](https://github.com/NixOS/nixpkgs/commit/93a6cd0fd6e5540bfbc40e38502425078d91d137) | `home-assistant: 2021.12.10 -> 2022.2.0`                               |
| [`cb9bb772`](https://github.com/NixOS/nixpkgs/commit/cb9bb7723736fc84c2ad7e9671538dd5c4b2c7ba) | `python3Packages.glances-api: 0.3.3 -> 0.3.4`                          |
| [`bbeaa3c7`](https://github.com/NixOS/nixpkgs/commit/bbeaa3c743b2fa2946e16a807fbefb52785405ee) | `python3Packages.zwave-js-server-python: 0.33.0 -> 0.34.0`             |
| [`82157ea5`](https://github.com/NixOS/nixpkgs/commit/82157ea5048f1fe16398d2cce4cfbfc87f6009b6) | `python3Packages.zeroconf: 0.38.1 -> 0.38.3`                           |
| [`09972dd2`](https://github.com/NixOS/nixpkgs/commit/09972dd20f76b596efd4b3c3488d6067e1e482eb) | `python3Packages.yalexs: 1.1.19 -> 1.1.20`                             |
| [`04fe5e98`](https://github.com/NixOS/nixpkgs/commit/04fe5e989440a477b54a08fe850be1b8a8f353cc) | `python3Packages.yalesmartalarmclient: 0.3.5 -> 0.3.7`                 |
| [`163b78f1`](https://github.com/NixOS/nixpkgs/commit/163b78f1a291b52436f649773d8d7ec2d171e060) | `python3Packages.xknx: 0.18.15 -> 0.19.1`                              |
| [`fd574e3c`](https://github.com/NixOS/nixpkgs/commit/fd574e3c6d1e82075ce971a42ab1791e7143bad8) | `python3Packages.wled: 0.11.0 -> 0.13.0`                               |
| [`cb3fad91`](https://github.com/NixOS/nixpkgs/commit/cb3fad914c0d4016e162e712c6b018b714d2445a) | `python3Packages.awesomeversion: 21.11.0 -> 22.1.0`                    |
| [`2bf4803b`](https://github.com/NixOS/nixpkgs/commit/2bf4803be8b050c74a865e19af2b85837a0fb176) | `python3Packages.soco: 0.25.3 -> 0.26.0`                               |
| [`90a1dc06`](https://github.com/NixOS/nixpkgs/commit/90a1dc061fb6170d0667162e045d99802fb7905d) | `python3Packages.sentry-sdk: 1.5.2 -> 1.5.4`                           |
| [`8e02e37b`](https://github.com/NixOS/nixpkgs/commit/8e02e37bb25c007874fba4cd5578722a119e4535) | `python3Packages.rflink: 0.0.58 -> 0.0.62`                             |
| [`734bdf9a`](https://github.com/NixOS/nixpkgs/commit/734bdf9aa16b6fe2ab8babdee7cb912b22688b6f) | `python3Packages.renault-api: 0.1.6 -> 0.1.7`                          |
| [`db4a4d52`](https://github.com/NixOS/nixpkgs/commit/db4a4d52a86d7d63963d8c6d7680cb4bcdc9a088) | `python3Packages.pysml: 0.0.5 -> 0.0.7`                                |
| [`7154c489`](https://github.com/NixOS/nixpkgs/commit/7154c489566decb6cbee3964a0024ab952425e89) | `python3Packages.pypck: 0.7.11 -> 0.7.13`                              |
| [`f4f6718a`](https://github.com/NixOS/nixpkgs/commit/f4f6718a58cf40719e1fea0628c5e37a24b91966) | `python3Packages.pynuki: 1.4.1 -> 1.5.2`                               |
| [`4e26847e`](https://github.com/NixOS/nixpkgs/commit/4e26847ee5b88df7667f10560cfc9752d542cb37) | `python3Packages.pynina: 2021-11-11 -> 0.1.4`                          |
| [`5aebf78f`](https://github.com/NixOS/nixpkgs/commit/5aebf78fbf703fa827574d52a7937a9bc08278be) | `python3Packages.pylitterbot: 2021.11.0 -> 2021.12.0`                  |
| [`1dbf51c3`](https://github.com/NixOS/nixpkgs/commit/1dbf51c3bef48aa53c1d87554ab2d3166770db7f) | `python3Packages.pyinsteon: 1.0.13 -> 1.0.14`                          |
| [`f239aa2e`](https://github.com/NixOS/nixpkgs/commit/f239aa2e297e57e98ce3119b20e7b02948e1dca7) | `python3Packages.pyezviz: 0.2.0.5 -> 0.2.0.6`                          |
| [`f6ae0ef0`](https://github.com/NixOS/nixpkgs/commit/f6ae0ef02e036bc18a56b2b9cca149eb90d6607b) | `python3Packages.pydaikin: 2.6.0 -> 2.7.0`                             |
| [`b940be13`](https://github.com/NixOS/nixpkgs/commit/b940be13b179f2c124a6d41cb1c6230b79b3fc51) | `python3Packages.pyatv: 0.9.8 -> 0.10.0`                               |
| [`d4767e42`](https://github.com/NixOS/nixpkgs/commit/d4767e4220cf2f423b38bb0c1e2aa1402bad1d42) | `python3Packages.mill-local: 0.1.0 -> 0.1.1`                           |
| [`b2a60329`](https://github.com/NixOS/nixpkgs/commit/b2a603297b75ac13a43e82e30c8b89e50dbb6285) | `python3Packages.influxdb: 5.3.0 -> 5.3.1`                             |
| [`6930626b`](https://github.com/NixOS/nixpkgs/commit/6930626b426db8a30da7f3ec328875abe1adce68) | `python3Packages.hass-nabucasa: 0.51.0 -> 0.52.0`                      |
| [`f84098a5`](https://github.com/NixOS/nixpkgs/commit/f84098a596e5cd904dfa75e880990c670868cadf) | `python3Packages.google-nest-sdm: 1.5.1 -> 1.6.0`                      |
| [`af86d240`](https://github.com/NixOS/nixpkgs/commit/af86d240e801fd57ad1da102ff034cdb31c09e7f) | `python3Packages.garages-amsterdam: 2.1.1 -> 3.2.1`                    |