### PR TITLE
chore(flake/poetry2nix): `5aa37b8a` -> `fc48a10e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1643757111,
-        "narHash": "sha256-LerUUhM/srtbYgc8x0+sIiTUv3FfjeNLxjZqZ/DQzlo=",
+        "lastModified": 1644099676,
+        "narHash": "sha256-8YxgJZXgeL6VoWGwuGuz44RokOqYsYEjYN6S7MBBR3E=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "5aa37b8a5652a4c2a2372e82815ebd15db07f087",
+        "rev": "fc48a10e02f218f6defe386c454a7ca43700145b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                    | Commit Message                                       |
| --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`43c600f3`](https://github.com/nix-community/poetry2nix/commit/43c600f3901236abd3971fcbf974c28fc52dc560) | `More various fixes`                                 |
| [`31effa4e`](https://github.com/nix-community/poetry2nix/commit/31effa4e4ef6df999b6f03449998b0b7ac6b0923) | `Add hook to remove normal files from site-packages` |
| [`add30389`](https://github.com/nix-community/poetry2nix/commit/add303897ff5e1fdbb11820a1bae0e71a234e89e) | `Watch niv files with direnv`                        |
| [`fafa7377`](https://github.com/nix-community/poetry2nix/commit/fafa7377027d11eb965e620db998a9347b111edc) | `Regenerate build-systems.json from updated nixpkgs` |
| [`4b2c6ac5`](https://github.com/nix-community/poetry2nix/commit/4b2c6ac56e109f07a02e225aebe761293be576bd) | `Bump nixpkgs`                                       |
| [`60e03da7`](https://github.com/nix-community/poetry2nix/commit/60e03da70ea77d2a3c96413dec6a1edcf5375d2a) | `Add dnspython override`                             |
| [`aee2824f`](https://github.com/nix-community/poetry2nix/commit/aee2824f4b6501b935bfc352c50aaca39554f460) | `Regenerate build-systems.json`                      |
| [`58e95427`](https://github.com/nix-community/poetry2nix/commit/58e95427d479330fd3316728f1eb587c76e709f8) | `Revert "fix utf8 emoji for strawberry-graphql"`     |
| [`b6b02d7f`](https://github.com/nix-community/poetry2nix/commit/b6b02d7fc22b11d6ad0691e25194a14ab3ad3cbe) | `Add test for utf8 (emoji) in pyproject.toml`        |
| [`fb2c617d`](https://github.com/nix-community/poetry2nix/commit/fb2c617d08dffff185047a7b6dfa89df34619b80) | `fix utf8 emoji for strawberry-graphql`              |
| [`4c802105`](https://github.com/nix-community/poetry2nix/commit/4c802105bcbee5ba3583b9024c678e4e10ba669b) | `add confluent-kafka`                                |
| [`62bab889`](https://github.com/nix-community/poetry2nix/commit/62bab8891f74ea334ef99862ac6d0ddcf0bb1656) | `Fix infinite recursion in project with flit-core`   |
| [`2b50ad86`](https://github.com/nix-community/poetry2nix/commit/2b50ad861210b4c4223d8754acc7b911bfbc71ee) | `testpath: Use flit as a build system`               |
| [`5747d0d7`](https://github.com/nix-community/poetry2nix/commit/5747d0d7da0a2599f0b858a05df8595bf0b4e547) | `Compile mypy once again`                            |
| [`832a24c9`](https://github.com/nix-community/poetry2nix/commit/832a24c9be3588caf703791043c0f009c4a0abdf) | `Build system for aioboto3 and aioitertools`         |