### PR TITLE
chore(flake/nixpkgs): `5c9b6ab9` -> `3e3f30af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643963578,
-        "narHash": "sha256-LYt6LTltbAe9qUqFKwESCKO/hd08lEHuJvRbeKMDfDQ=",
+        "lastModified": 1644093253,
+        "narHash": "sha256-hiabwdySBt3UKO3m4h0RCZ6DdxaT58NoympcWkjkocc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5c9b6ab9ca4e3963cf0de8f8f331a3eeb0d481aa",
+        "rev": "3e3f30afd29d9ad3345d6feb4a058c11793c1fb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                          |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`8ec81faf`](https://github.com/NixOS/nixpkgs/commit/8ec81fafb6ccea03003e18618f51e94ec3f2e3e4) | `solo5: patch solo5-virtio-mkimage to use our Syslinux, etc`            |
| [`1bfc1730`](https://github.com/NixOS/nixpkgs/commit/1bfc1730e13e821d911d0c289444756e86d7aa08) | `cwltool: 3.1.20220202173120 -> 3.1.20220204090313 (#158272)`           |
| [`d773c65e`](https://github.com/NixOS/nixpkgs/commit/d773c65e2b4106175691be7347491a2b2dfa4f34) | `networkmanager-l2tp: add missing dependency`                           |
| [`7a2f5659`](https://github.com/NixOS/nixpkgs/commit/7a2f565909d835c60695817a91b414ae108b6892) | `networkmanager-openvpn: add missing dependency`                        |
| [`05f127a9`](https://github.com/NixOS/nixpkgs/commit/05f127a994f14b21510697c4e11ad15b23298767) | `dune_2: 2.9.2 → 2.9.3`                                                 |
| [`db7940a8`](https://github.com/NixOS/nixpkgs/commit/db7940a8996cf9dea6219e39b23cb17af41866a0) | `unpackerr: 0.9.8 -> 0.9.9`                                             |
| [`1bbaabbf`](https://github.com/NixOS/nixpkgs/commit/1bbaabbf44faf22797762249caaaab3bc54d34d3) | `gdown: 4.2.0 -> 4.2.1`                                                 |
| [`260128ce`](https://github.com/NixOS/nixpkgs/commit/260128ce579d314dd0383f09f42bfc82b84de4ef) | `tev: 1.22 -> 1.23`                                                     |
| [`07abf694`](https://github.com/NixOS/nixpkgs/commit/07abf6942f5ef56a98ba5224a8c789e0bb1ee89c) | `nixos/users:added users.allowLoginless`                                |
| [`d3258ef8`](https://github.com/NixOS/nixpkgs/commit/d3258ef811ef3a20a37cfeb2f7deb07429b3bb0c) | `python310Packages.adax-local: 0.1.3 -> 0.1.4`                          |
| [`626fb2d5`](https://github.com/NixOS/nixpkgs/commit/626fb2d515bbf718c6803d798521f24497bac0b7) | `heroku: 7.59.0 -> 7.59.2`                                              |
| [`5d374e47`](https://github.com/NixOS/nixpkgs/commit/5d374e47f5ea866fb6c59aa526916dafc8649857) | `python310Packages.soco: 0.26.0 -> 0.26.1`                              |
| [`4ef8f177`](https://github.com/NixOS/nixpkgs/commit/4ef8f177a4b58ce83196221a5bafb527192d3764) | `v2ray-geoip: 202201270031 -> 202202030030`                             |
| [`3f323d74`](https://github.com/NixOS/nixpkgs/commit/3f323d74d634a975bf4a71a1cda632c212c7f163) | `nixpkgs-basic-release-checks.nix: print errors`                        |
| [`87631775`](https://github.com/NixOS/nixpkgs/commit/87631775cb761bdf61f5f223f28a977f515cb203) | `neovide: 2021-10-09 -> 2022-02-04`                                     |
| [`6afcc5af`](https://github.com/NixOS/nixpkgs/commit/6afcc5afc63f1bf6e3c904ba5afac5a76a937af0) | `nixos/connman: fix evaluation`                                         |
| [`8f608f43`](https://github.com/NixOS/nixpkgs/commit/8f608f437a6dd9847f86cbc22bb134dede73fd4e) | `rcs: 5.10.0 -> 5.10.1`                                                 |
| [`dff8621d`](https://github.com/NixOS/nixpkgs/commit/dff8621d05f7f0249686ad78ef9b722bb72320a4) | `exploitdb: 2022-02-03 -> 2022-02-05`                                   |
| [`cb18e6cd`](https://github.com/NixOS/nixpkgs/commit/cb18e6cd01166834d8b731fbe76d6ed4fd2e08c0) | `nixos/docker-rootless: disable for root`                               |
| [`9d65a3bd`](https://github.com/NixOS/nixpkgs/commit/9d65a3bd2d42be39c0c0da954d82610161a7261c) | `jove: fix typo in package description`                                 |
| [`7ee48426`](https://github.com/NixOS/nixpkgs/commit/7ee4842601dc74bf60b671e08f204f44854e3812) | `vimPlugins.material-nvim: init at 2022-02-04`                          |
| [`19703f0e`](https://github.com/NixOS/nixpkgs/commit/19703f0eda6da449fe5eb0066d9f12eeb8137587) | `vimPlugins.zen-mode-nvim: init at 2021-11-07`                          |
| [`727ccbad`](https://github.com/NixOS/nixpkgs/commit/727ccbadae815da87d6b59d541b74907cd414548) | `python3Packages.asyncstdlib: 3.10.2 -> 3.10.3`                         |
| [`04d91b9a`](https://github.com/NixOS/nixpkgs/commit/04d91b9ac19d133c2ae607bce7c99e500b1468be) | `vimPlugins: update`                                                    |
| [`ef63ee95`](https://github.com/NixOS/nixpkgs/commit/ef63ee95049d36d94c921629c1a766cdd81387ee) | `chrootenv: remove default.nix from src`                                |
| [`deb06498`](https://github.com/NixOS/nixpkgs/commit/deb06498e0355be3027f83e94ad74ad2d9081547) | `go_1_18: 1.18beta1 -> 1.18beta2`                                       |
| [`1505b2e4`](https://github.com/NixOS/nixpkgs/commit/1505b2e44e41071ff7212fd8fc62c2d694185e93) | `papirus-icon-theme: 20211201 -> 20220204`                              |
| [`5c11ca25`](https://github.com/NixOS/nixpkgs/commit/5c11ca256fe174aedcd43c71a73bc258e1eca105) | `gron: switch to go_1_17`                                               |
| [`b859bcb9`](https://github.com/NixOS/nixpkgs/commit/b859bcb9eb883fba8bb0d85ddc7a87ec4195acc2) | `ocamlPackages.ppxfind: remove`                                         |
| [`d2a7b176`](https://github.com/NixOS/nixpkgs/commit/d2a7b1764046686e5819bb31123bb1e381ec006e) | `reproxy: switch to go_1_17`                                            |
| [`a6f6c0f0`](https://github.com/NixOS/nixpkgs/commit/a6f6c0f0ade9c55a024ecbbb8a5362af0bd6d55b) | `victoriametrics: switch to go_1_17`                                    |
| [`0acef310`](https://github.com/NixOS/nixpkgs/commit/0acef310fea437e8fc328bee87142edd491857a7) | `open-policy-agent: switch to go_1_17`                                  |
| [`080dc8d8`](https://github.com/NixOS/nixpkgs/commit/080dc8d8c7cf1f14f133299218f3eba0f567daf4) | `datadog-agent: switch to go_1_17 `                                     |
| [`c09b2057`](https://github.com/NixOS/nixpkgs/commit/c09b2057a66c139e832c3b4dc1a716d12e0b1395) | `tendermint: switch to go_1_17 `                                        |
| [`f0c78d81`](https://github.com/NixOS/nixpkgs/commit/f0c78d817489ad7723f3a1b79d2105d53b00a2b5) | `uchess: switch to go_1_17`                                             |
| [`84b369d2`](https://github.com/NixOS/nixpkgs/commit/84b369d2fdf5b985faeb92f6d66946b21232f9ad) | `waylandpp: 0.2.8 -> 0.2.9`                                             |
| [`1766d4bc`](https://github.com/NixOS/nixpkgs/commit/1766d4bc0980afd8ea5ae1d872fd3adb29e000dc) | `super-slicer: 2.3.57.9 -> 2.3.57.10`                                   |
| [`3422273b`](https://github.com/NixOS/nixpkgs/commit/3422273b30e6bb4373b6e9b60f37f0d655b25508) | `himalaya: 0.5.1 → 0.5.4`                                               |
| [`5aaf3d7b`](https://github.com/NixOS/nixpkgs/commit/5aaf3d7b59e67021ad8c5a1dbbf31eb2f72b0f38) | `songrec: 0.2.1 -> 0.3.0`                                               |
| [`59add637`](https://github.com/NixOS/nixpkgs/commit/59add637ca2fbd73d1b01c8da71aea0dfec62cdd) | `metasploit: 6.1.27 -> 6.1.28`                                          |
| [`04811c34`](https://github.com/NixOS/nixpkgs/commit/04811c34b7b4fd9a274f9e95c9d2d4de2c69661f) | `python3Packages.aresponses: 2.1.4 -> 2.1.5`                            |
| [`1fdd3a53`](https://github.com/NixOS/nixpkgs/commit/1fdd3a53ad4e7820ef5695a7dd6d9d61086484c9) | `spidermonkey_91: 91.5.0 -> 91.5.1`                                     |
| [`58dd3b03`](https://github.com/NixOS/nixpkgs/commit/58dd3b034880ec20b724c13a8095c1ca2cc49298) | `python3Packages.cattrs: 1.8.0 -> 1.10.0`                               |
| [`825deace`](https://github.com/NixOS/nixpkgs/commit/825deacec27ea9317cb5aa39105d7f8787fc63c7) | `vintagestory: 1.16.1 -> 1.16.3`                                        |
| [`80833d9a`](https://github.com/NixOS/nixpkgs/commit/80833d9a2bf529053d1e86fa801f7aa065c09eab) | `steam-run: inherit /etc/profile fixes`                                 |
| [`e9a183f5`](https://github.com/NixOS/nixpkgs/commit/e9a183f536d8d0bfdd81f8ad95b30d43aeaff2af) | `kubebuilder: 3.2.0 -> 3.3.0`                                           |
| [`3c8f4469`](https://github.com/NixOS/nixpkgs/commit/3c8f4469e26b8615baa160906061a25f18d2ad51) | `ledger-live-desktop: 2.36.3 -> 2.37.2`                                 |
| [`ff102452`](https://github.com/NixOS/nixpkgs/commit/ff102452dd366e913ebc70b7387a1d267c96dd20) | `rofi-emoji: 2.2.0 -> 2.3.0`                                            |
| [`5cb9fbd5`](https://github.com/NixOS/nixpkgs/commit/5cb9fbd5fffaa5e88e768db14fca4ba6f12e5a91) | `rocketchat-desktop: 3.7.6 -> 3.7.7`                                    |
| [`d7c728f6`](https://github.com/NixOS/nixpkgs/commit/d7c728f6ef77948a3bb9b210100b7b5b52404f0f) | `fluxcd: 0.25.3 -> 0.26.1`                                              |
| [`e52a4eb0`](https://github.com/NixOS/nixpkgs/commit/e52a4eb0a8a7ec035a62f6578a67cb61522a319d) | `python310Packages.databricks-cli: 0.16.2 -> 0.16.4`                    |
| [`1d5cfd2d`](https://github.com/NixOS/nixpkgs/commit/1d5cfd2d907db1d725199c29d71108cf16f9b53b) | `python310Packages.pydy: 0.5.0 -> 0.6.0`                                |
| [`4daa4bf5`](https://github.com/NixOS/nixpkgs/commit/4daa4bf5350b722ee72246dadda9e7699ce739f7) | `ffmpeg-normalize: 1.22.4 -> 1.22.5`                                    |
| [`e8662b66`](https://github.com/NixOS/nixpkgs/commit/e8662b6688ff790102b01c3c6c176e98fb1dca88) | `love: 0.10.2 -> 11.4`                                                  |
| [`e2384303`](https://github.com/NixOS/nixpkgs/commit/e2384303a0ecd7f8e0982d87d0a82f768aca22cd) | `slack: 4.22.0 -> 4.23.0`                                               |
| [`dc025b05`](https://github.com/NixOS/nixpkgs/commit/dc025b056808885ae5fd6716dfe25ef3469b89fe) | `sabnzbd: 3.4.2 -> 3.5.0`                                               |
| [`69686e74`](https://github.com/NixOS/nixpkgs/commit/69686e74a4550d054ff091b71b330ff9593156cc) | `python310Packages.policy-sentry: 0.12.1 -> 0.12.2`                     |
| [`baca6407`](https://github.com/NixOS/nixpkgs/commit/baca640798571218743fca3cd665194b3af9d16b) | `ent-go: init 0.10.0`                                                   |
| [`7a33dcf4`](https://github.com/NixOS/nixpkgs/commit/7a33dcf46080aeef1dc98cfdbebd4f035bee938c) | `tts: 0.4.2 -> 0.5.0`                                                   |
| [`6994e8ae`](https://github.com/NixOS/nixpkgs/commit/6994e8ae17182ff71127a053fc71c6fa21352bc1) | `cmctl: init 1.7.1`                                                     |
| [`c08df24d`](https://github.com/NixOS/nixpkgs/commit/c08df24d0256e9d01bd41cdb69363dd2b07006c9) | `maintainers: add superherointj`                                        |
| [`0ac70967`](https://github.com/NixOS/nixpkgs/commit/0ac709674059d04ec9bc7975160ae4c6eaaccfd5) | `chromiumDev: 99.0.4844.16 -> 100.0.4867.0`                             |
| [`1d902f69`](https://github.com/NixOS/nixpkgs/commit/1d902f69ef7151673879267ca63b0ec7942da8c5) | `chromiumBeta: 98.0.4758.80 -> 99.0.4844.17`                            |
| [`490d9418`](https://github.com/NixOS/nixpkgs/commit/490d9418b32eb705c1fc40c3e8da5fac272e7604) | `teleport: 8.1.1 -> 8.1.3`                                              |
| [`8c742111`](https://github.com/NixOS/nixpkgs/commit/8c742111553a3d22ee50ac61f2b779078a54d28d) | `jenkins-job-builder: 3.11.0 -> 3.12.0`                                 |
| [`0fd8f31f`](https://github.com/NixOS/nixpkgs/commit/0fd8f31f3309d4751780b1aa4be68d41176ff7ec) | `libplacebo: 4.192.0 -> 4.192.1`                                        |
| [`80a70ce0`](https://github.com/NixOS/nixpkgs/commit/80a70ce0d515f5bc905156cd6e7afe88fd24b35a) | `electrs: 0.9.4 -> 0.9.5`                                               |
| [`b7404f6d`](https://github.com/NixOS/nixpkgs/commit/b7404f6d94e96fabec9ed455fbc53cda1f24cbae) | `weston: 9.0.0 -> 10.0.0`                                               |
| [`7b504605`](https://github.com/NixOS/nixpkgs/commit/7b504605c3103f57562eeeaec0e508e44ee15a91) | `home-assistant: 2022.2.1 -> 2022.2.2`                                  |
| [`ecc2d067`](https://github.com/NixOS/nixpkgs/commit/ecc2d067207617daf33b2bee6f5a7852cbe7d20f) | `python3Packages.renault-api: 0.1.7 -> 0.1.8`                           |
| [`1aeccfa6`](https://github.com/NixOS/nixpkgs/commit/1aeccfa6f7c29b1e6337b62c9bddac97df374c6a) | `python3Packages.aiogithubapi: 22.1.2 -> 22.2.0`                        |
| [`a12cfff5`](https://github.com/NixOS/nixpkgs/commit/a12cfff5b27abaf3f888ab1e28ca24c4784acfb4) | `ungoogled-chromium: 97.0.4692.99 -> 98.0.4758.80`                      |
| [`2cff8bed`](https://github.com/NixOS/nixpkgs/commit/2cff8bed2fe7f5729f42a792ba3358024d6e7157) | `labwc: Fix the build with wlroots 0.15.1`                              |
| [`57db7bcd`](https://github.com/NixOS/nixpkgs/commit/57db7bcdd66024424c74480e05f57d23c78c9d8e) | `nixos/matrix-conduit: add database_backend option`                     |
| [`a9c5c63c`](https://github.com/NixOS/nixpkgs/commit/a9c5c63cbc288e46807557e392e8eb7af6d5e5ce) | `matrix-conduit: 0.2.0 -> 0.3.0`                                        |
| [`fe636b48`](https://github.com/NixOS/nixpkgs/commit/fe636b480568b1b5a50b7a406bb425d24fcc60de) | `nixos/networking: Typo fix`                                            |
| [`9736bfc3`](https://github.com/NixOS/nixpkgs/commit/9736bfc3732324635539c29ccb1af39044602cf1) | `matrix-conduit: add pimeys as maintainer`                              |
| [`40bc60f5`](https://github.com/NixOS/nixpkgs/commit/40bc60f594a747dcd1c431150a07c211f1df3611) | `signal-desktop: 5.29.1 -> 5.30.0`                                      |
| [`673c89dc`](https://github.com/NixOS/nixpkgs/commit/673c89dc34173077415f19df9da7b571ce6b07e9) | `python310Packages.google-cloud-texttospeech: 2.9.1 -> 2.10.0`          |
| [`b2cb244b`](https://github.com/NixOS/nixpkgs/commit/b2cb244b37138c3714d1b0d68b6c51155f0cce8c) | `hyper: 3.1.4 -> 3.2.0 (#158124)`                                       |
| [`2dce6e7a`](https://github.com/NixOS/nixpkgs/commit/2dce6e7aa09ce84e3f483b73c1e5f7fe248214f7) | `lnd: 0.14.1-beta -> 0.14.2-beta`                                       |
| [`0d737162`](https://github.com/NixOS/nixpkgs/commit/0d737162783a4f5bdc03575a062f674d5bb2e80d) | `trilium: 0.49.5 -> 0.50.1`                                             |
| [`512f4924`](https://github.com/NixOS/nixpkgs/commit/512f492406e2d9b3cbe0ecbcf541b396a1102a39) | `tfsec: 0.63.1 -> 1.0.11`                                               |
| [`10af7399`](https://github.com/NixOS/nixpkgs/commit/10af7399071083fe5a25edb1b0771c4abf5f1b2f) | `step-cli: 0.17.7 -> 0.18.0`                                            |
| [`1e8a3ffe`](https://github.com/NixOS/nixpkgs/commit/1e8a3ffe29ef81f18067ee3eeac21f6f38b4f67f) | `syncthing: 1.18.6 -> 1.19.0`                                           |
| [`4a21bd1c`](https://github.com/NixOS/nixpkgs/commit/4a21bd1c873c92e2c2d9ca3f3f3453a4f6cf00f3) | `traitor: 0.0.8 -> 0.0.9`                                               |
| [`783b8b85`](https://github.com/NixOS/nixpkgs/commit/783b8b85cf424e71c7b2b37c8dc0d0d8c2b0639e) | ``fcitx5: update `update.py` script``                                   |
| [`8ccd703c`](https://github.com/NixOS/nixpkgs/commit/8ccd703cc087577d2c3a5cdf859ab495c183561c) | `prowlarr: 0.1.10.1375 -> 0.2.0.1448`                                   |
| [`1fcccf03`](https://github.com/NixOS/nixpkgs/commit/1fcccf03d528c6f2aa8f047dd5bf318bb7446e1f) | `python310Packages.google-cloud-kms: 2.10.1 -> 2.11.0`                  |
| [`ac6b4774`](https://github.com/NixOS/nixpkgs/commit/ac6b477499a13d628e7901544a6e29b57843f3a0) | `wlroots: 0.15.0 -> 0.15.1`                                             |
| [`4c65928e`](https://github.com/NixOS/nixpkgs/commit/4c65928e00698a0d0be9a61a20e0ac4606f3385e) | `python3Packages.img2pdf: fix tests with Pillow 9`                      |
| [`40af850b`](https://github.com/NixOS/nixpkgs/commit/40af850b99185933bca50ad533bbfbdbf4118c1b) | `pipewire: 0.3.44 -> 0.3.45`                                            |
| [`3beb2a3a`](https://github.com/NixOS/nixpkgs/commit/3beb2a3aff32a380ca9b511270e4044ae283bf08) | `pipewire: 0.3.43 -> 0.3.44`                                            |
| [`ffe7f27e`](https://github.com/NixOS/nixpkgs/commit/ffe7f27eb3ebe6f3c9847b906ddf416bd511e7ea) | `gitlab: 14.7.0 -> 14.7.1 (#158069)`                                    |
| [`4783944a`](https://github.com/NixOS/nixpkgs/commit/4783944ae50f2c8e4f946007950f6246bac6bf4b) | `faas-cli: 0.14.1 -> 0.14.2`                                            |
| [`91bbd310`](https://github.com/NixOS/nixpkgs/commit/91bbd310689753df138ae575aeece723475871c6) | `bingrep: 0.8.5 -> 0.9.0`                                               |
| [`7194bfac`](https://github.com/NixOS/nixpkgs/commit/7194bfac5a757a6aa55e474410a4081cfc154c76) | `home-assistant: 2022.2.0 -> 2022.2.1`                                  |
| [`c18ca8f8`](https://github.com/NixOS/nixpkgs/commit/c18ca8f8adef6aab23a2a6ca581ead6785dc0902) | `python3Packages.pytile: 2022.01.0 -> 2022.02.0`                        |
| [`3020762c`](https://github.com/NixOS/nixpkgs/commit/3020762c1e32397ecd57bc2bdd9da625abed636f) | `ipfs-migrator: pin to go_1_16`                                         |
| [`36e44512`](https://github.com/NixOS/nixpkgs/commit/36e44512d7d60d60844149fb615faf471a44f2d7) | `ipfs: pin to go_1_16`                                                  |
| [`2176aca4`](https://github.com/NixOS/nixpkgs/commit/2176aca4650e4ec1e0244bff56ce8983fe355b57) | `datadog-agent: pin to go_1_16`                                         |
| [`e8ff81ed`](https://github.com/NixOS/nixpkgs/commit/e8ff81edb79b433f6574c4866b2ebfde4888f950) | `nixos/self-deploy: make systemd dependency conditional`                |
| [`d1ec33e8`](https://github.com/NixOS/nixpkgs/commit/d1ec33e8a803ee93d4f11455a28b9d1ba07bf956) | `jameica 2.10.0 -> 2.10.1`                                              |
| [`28ce0594`](https://github.com/NixOS/nixpkgs/commit/28ce05941567c3d6f02f1334976301839a18bbb0) | `cargo-xbuild: 0.6.2 -> 0.6.5`                                          |
| [`3410d872`](https://github.com/NixOS/nixpkgs/commit/3410d872a3e4c51894bd4d7b04e1f1bc300de355) | `xplr: 0.17.1 -> 0.17.2`                                                |
| [`3b8fa47f`](https://github.com/NixOS/nixpkgs/commit/3b8fa47f58bd96b59bdcd9a14b36ad2ee9d0d8f0) | `nixos/wireless: don't attempt fallback on WPA3 only networks`          |
| [`e4bdf78d`](https://github.com/NixOS/nixpkgs/commit/e4bdf78d8108660238e47ce23bcbb1e07f8ea395) | `exploitdb: 2022-01-29 -> 2022-02-03`                                   |
| [`3c22d451`](https://github.com/NixOS/nixpkgs/commit/3c22d451670f55179290c7f575e13fa82e441a60) | `yt-dlp: 2022.2.3 -> 2022.2.4`                                          |
| [`ceb1e045`](https://github.com/NixOS/nixpkgs/commit/ceb1e0457dcf71e6333b0f6fb13d7ea6a2d0a705) | `python3Packages.flux-led: 0.28.17 -> 0.28.20`                          |
| [`959317df`](https://github.com/NixOS/nixpkgs/commit/959317df95eb0819aaa5ff65e6f40e124c762437) | `nixos/syncplay: fix systemd service`                                   |
| [`a2dae691`](https://github.com/NixOS/nixpkgs/commit/a2dae6912dc3db01a79db55471275e0826c0c63d) | `fnotifystat: fix license gpl2 -> gpl2+`                                |
| [`f2428dfb`](https://github.com/NixOS/nixpkgs/commit/f2428dfba320e13cb1ff5ee64743d9edd1a5fa14) | `procdump: enable parallel building`                                    |
| [`abcf236f`](https://github.com/NixOS/nixpkgs/commit/abcf236f3644451be466dfea7c4605f27af15d1d) | `nixosTests.sway: add swaylock test`                                    |
| [`c39cc2e8`](https://github.com/NixOS/nixpkgs/commit/c39cc2e840e1fe51a85b3207cf3561802af9c997) | `nixosTests.sway: factor out swaymsg`                                   |
| [`aca22fb1`](https://github.com/NixOS/nixpkgs/commit/aca22fb1246b5043a8f9ed606efa8885a71e320f) | `nixosTests.sway: format with nixpkgs-fmt`                              |
| [`3966f3af`](https://github.com/NixOS/nixpkgs/commit/3966f3af2ea8b9332e58c0f4d5fe84182f6328e0) | `dovecot_pigeonhole: 0.5.17.1 -> 0.5.18`                                |
| [`18d27ba1`](https://github.com/NixOS/nixpkgs/commit/18d27ba1486197ca3a1a690b4da030e3fbeb0900) | `dovecot: 2.3.17.1 -> 2.3.18`                                           |
| [`92d7fa37`](https://github.com/NixOS/nixpkgs/commit/92d7fa372bbba9880c362a4df2fdcb2bfce359ef) | `ArchiSteamFarm: 5.2.1.5 -> 5.2.2.4; ASF-ui: update`                    |
| [`2ab85940`](https://github.com/NixOS/nixpkgs/commit/2ab8594045c1bb3c6de2b1b94dfb0abdda28a5dd) | `kopia: 0.10.3 -> 0.10.4`                                               |
| [`eaa576d0`](https://github.com/NixOS/nixpkgs/commit/eaa576d02886569b6d1ba89e96c4b173247e0fe9) | `linux/hardened/patches/5.4: 5.4.173-hardened1 -> 5.4.176-hardened1`    |
| [`3e23004d`](https://github.com/NixOS/nixpkgs/commit/3e23004d64886cb1a4926ccaa93ee9a6b779a125) | `linux/hardened/patches/5.15: 5.15.16-hardened1 -> 5.15.19-hardened1`   |
| [`f529fa4f`](https://github.com/NixOS/nixpkgs/commit/f529fa4f4e2eed3555e503c410129c1467757507) | `linux/hardened/patches/5.10: 5.10.93-hardened1 -> 5.10.96-hardened1`   |
| [`84bf08c2`](https://github.com/NixOS/nixpkgs/commit/84bf08c27e982b1506ee1c80daf67e2a0fe91240) | `linux/hardened/patches/4.19: 4.19.225-hardened1 -> 4.19.227-hardened1` |
| [`665abd52`](https://github.com/NixOS/nixpkgs/commit/665abd52577c5ab15490c362e5065a2583bc6c69) | `linux/hardened/patches/4.14: 4.14.262-hardened1 -> 4.14.264-hardened1` |
| [`35f965fc`](https://github.com/NixOS/nixpkgs/commit/35f965fc61fb4188855c6e3f2aecbde8047858e1) | `linux_latest-libre: 18517 -> 18587`                                    |
| [`4ee1c3ad`](https://github.com/NixOS/nixpkgs/commit/4ee1c3ad902e5141eb59f325af6a1f2732d1862d) | `linux: 5.4.175 -> 5.4.176`                                             |
| [`5aeb9976`](https://github.com/NixOS/nixpkgs/commit/5aeb99768b2a1f0538ff1f6a21994746be0fc73b) | `linux: 5.16.4 -> 5.16.5`                                               |
| [`af5cda7f`](https://github.com/NixOS/nixpkgs/commit/af5cda7f793a37d19736af1e731dcb7ea0d583d1) | `linux: 5.15.18 -> 5.15.19`                                             |
| [`a752a237`](https://github.com/NixOS/nixpkgs/commit/a752a2371a8fbead1be437d28fc92423a35c36d0) | `linux: 5.10.95 -> 5.10.96`                                             |
| [`4e53ba1b`](https://github.com/NixOS/nixpkgs/commit/4e53ba1b1b91f2d8f766d98917ccb2d4ef99f9d1) | `linux: 4.4.301 -> 4.4.302`                                             |
| [`de047988`](https://github.com/NixOS/nixpkgs/commit/de047988f5a6ad007d046ddc81d1d005f77d8e96) | `apprise: 0.9.6 -> 0.9.7`                                               |
| [`c4026764`](https://github.com/NixOS/nixpkgs/commit/c40267640ae0c208b1e24529a55dd55cb49830bd) | `fcitx5-m17n: 5.0.6 -> 5.0.8`                                           |
| [`246b211f`](https://github.com/NixOS/nixpkgs/commit/246b211ffa01d639d1d1360a02df0ab996165490) | `pueue: 1.0.4 -> 1.0.6`                                                 |
| [`37cfd9fe`](https://github.com/NixOS/nixpkgs/commit/37cfd9fef8622bfe130ae033d227e6e324f837d8) | `release-small: prune more obsolete software`                           |
| [`01ed75f0`](https://github.com/NixOS/nixpkgs/commit/01ed75f039c4433c9c1c2c20b0463edd98b25b48) | `linode-cli: 5.15.0 -> 5.16.0`                                          |
| [`49268792`](https://github.com/NixOS/nixpkgs/commit/49268792710c34633fcfbd261b746cfe9af1576b) | `packer: 1.7.9 -> 1.7.10`                                               |
| [`d274444a`](https://github.com/NixOS/nixpkgs/commit/d274444a68afc02d7950f41c7e29a5cad9ed386b) | `hydrus: 471 -> 472`                                                    |
| [`97c0ce62`](https://github.com/NixOS/nixpkgs/commit/97c0ce62adf48106ce9f5eec5225944068f2988c) | `vengi-tools: update repo and website URLs`                             |
| [`50dae31a`](https://github.com/NixOS/nixpkgs/commit/50dae31a148317bdf892cffb4e6b03d038cb2b49) | `vengi-tools: remove failing roundtrip test`                            |
| [`8ed1c056`](https://github.com/NixOS/nixpkgs/commit/8ed1c056225502e3662c8b7ff0fd6e9181b79727) | `vengi-tools: add convert all formats test`                             |
| [`c1366d7f`](https://github.com/NixOS/nixpkgs/commit/c1366d7fb90ad2939f949dadb97ba5a9d00541d5) | `vengi-tools: unpin cmake`                                              |
| [`e175845d`](https://github.com/NixOS/nixpkgs/commit/e175845d6171778ff49b615b5ed7a08dda1387b4) | `vengi-tools: 0.0.14 -> 0.0.17`                                         |
| [`61a15bd3`](https://github.com/NixOS/nixpkgs/commit/61a15bd35ba7efe7edd47afb3924ac3c14a1d6bb) | `obconf: Re-init at unstable-2015-02-13`                                |
| [`42323524`](https://github.com/NixOS/nixpkgs/commit/4232352443de968a420ece0c16e38ea4215e7682) | `mercurial: 6.0.1 -> 6.0.2`                                             |
| [`b10399bf`](https://github.com/NixOS/nixpkgs/commit/b10399bf398aaa20e2b1968131e358e33ee256d7) | `Electrum-grs: init at 4.1.5`                                           |
| [`b9fa206f`](https://github.com/NixOS/nixpkgs/commit/b9fa206fe30a4dfe12e7567f32ce30007f7b04b8) | `android-studio-canary: 2021.2.1.5 → 2021.3.1.1`                        |
| [`865fa855`](https://github.com/NixOS/nixpkgs/commit/865fa855a93ef3430d47c406570f5ce605c76926) | `android-studio-beta: 2021.1.1.18 → 2021.2.1.8`                         |
| [`94cd939c`](https://github.com/NixOS/nixpkgs/commit/94cd939c4928fffb552742f82a28c38bc3e6d9e9) | `jetbrains: update`                                                     |
| [`d77eae8f`](https://github.com/NixOS/nixpkgs/commit/d77eae8f75ca8fa48c90401ab2a60c3a0a4bad45) | `fulcrum: init at 1.6.0`                                                |
| [`53be4bd1`](https://github.com/NixOS/nixpkgs/commit/53be4bd13cb8f25ab93a92d1373ad66178e9aec6) | `limesurvey: 3.23.7+201006 -> 3.27.33+220125`                           |
| [`04e546b9`](https://github.com/NixOS/nixpkgs/commit/04e546b93148b4c31026a14fb3edae876816105e) | `hugo: 0.92.0 -> 0.92.1`                                                |
| [`42a800dd`](https://github.com/NixOS/nixpkgs/commit/42a800dd215481a931cbecdf8ef6a8f709d66b35) | `scalafmt: 3.3.1 -> 3.4.0`                                              |
| [`3cfe8235`](https://github.com/NixOS/nixpkgs/commit/3cfe8235e4a4c6fa55b389d4cdea560adabea8e2) | `python3Packages.wandb: 0.12.9 -> 0.12.10`                              |
| [`00f80f36`](https://github.com/NixOS/nixpkgs/commit/00f80f36d2822c5426bd3e15cb14598159269429) | `qtwebengine: 5.15.7 -> 5.15.8`                                         |
| [`4e9a5ef3`](https://github.com/NixOS/nixpkgs/commit/4e9a5ef3bccd4e0c4fc5154a7c4807d22fca6636) | `dogdns: install man pages`                                             |
| [`de5a2235`](https://github.com/NixOS/nixpkgs/commit/de5a2235621134434a932f0c6c97c0ddf83f4da2) | `dogdns: 0.1.0 -> unstable-2021-10-07`                                  |
| [`0f9e4b6f`](https://github.com/NixOS/nixpkgs/commit/0f9e4b6fe47ad580b8b2f0a15dfe381f41829520) | `pt2-clone: 1.39 -> 1.40`                                               |
| [`ba0ed336`](https://github.com/NixOS/nixpkgs/commit/ba0ed3368f51ee3065d741409b40ee7323149cbb) | `tutanota-desktop: 3.89.25 -> 3.91.6`                                   |
| [`f5b67f3b`](https://github.com/NixOS/nixpkgs/commit/f5b67f3b27bcd60a15a72384faaa93266d12fff9) | `nixos/sudo: fix test for 1.9.9`                                        |
| [`58eeb074`](https://github.com/NixOS/nixpkgs/commit/58eeb07420a33f33c1a587b11e27011812cf412b) | `fnotifystat: fix src/homepage, moved to github`                        |