### PR TITLE
chore(flake/nixpkgs): `5c9b6ab9` -> `8cec3cc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643963578,
-        "narHash": "sha256-LYt6LTltbAe9qUqFKwESCKO/hd08lEHuJvRbeKMDfDQ=",
+        "lastModified": 1644269936,
+        "narHash": "sha256-Pxn2au1JChCuxiKtmF8hpV7DyvKrCYd0vLzZGjGV0VE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5c9b6ab9ca4e3963cf0de8f8f331a3eeb0d481aa",
+        "rev": "8cec3cc29e2bc2a7dea71de46d3fd4441700de2e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                         |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`8cec3cc2`](https://github.com/NixOS/nixpkgs/commit/8cec3cc29e2bc2a7dea71de46d3fd4441700de2e) | `vimPlugins.vim-nixhash: init at 2022-02-06`                                           |
| [`32d2af12`](https://github.com/NixOS/nixpkgs/commit/32d2af12f242bfc87cb67fc4337afd9d15b3f809) | `vimPlugins: update`                                                                   |
| [`4422196e`](https://github.com/NixOS/nixpkgs/commit/4422196ea9cac74f595ecd6f63028af96d75c8ee) | `python310Packages.jq: 1.2.1 -> 1.2.2`                                                 |
| [`5749c2be`](https://github.com/NixOS/nixpkgs/commit/5749c2be28241c7abd1632bea061802dad2ff44f) | `python3Packages.pytibber: 0.22.0 -> 0.22.1`                                           |
| [`3724b8cf`](https://github.com/NixOS/nixpkgs/commit/3724b8cfa8436b9ced841078a8934584b692fc79) | `idrisPackages.protobuf: move to alias set`                                            |
| [`21e7625d`](https://github.com/NixOS/nixpkgs/commit/21e7625d6854a95d1ecb4e463a7f1e52513ad7b4) | `bloomrpc: init at 1.5.3 (#120292)`                                                    |
| [`cb648f08`](https://github.com/NixOS/nixpkgs/commit/cb648f080dba0fd0b953686c43b0ce05d0ed9ef2) | `wg-netmanager: init at 0.3.6 (#155149)`                                               |
| [`87ef1e84`](https://github.com/NixOS/nixpkgs/commit/87ef1e84fd0b75a6e1c7dcab0fed06cb08d6f34c) | `slack: fix linux url and updater`                                                     |
| [`e4ac3450`](https://github.com/NixOS/nixpkgs/commit/e4ac34506a0e06ce77368c569bb2fb294a72f0f2) | `tdesktop: Remove myself as maintainer`                                                |
| [`faa11fc7`](https://github.com/NixOS/nixpkgs/commit/faa11fc73b4ef2438235e1a0b1004f0841854a98) | `freedv: 1.6.1 -> 1.7.0`                                                               |
| [`bbace3e7`](https://github.com/NixOS/nixpkgs/commit/bbace3e730ababc8fadd57f7b03fd18db010725e) | `node-packages.nix: generate`                                                          |
| [`3e2a8d53`](https://github.com/NixOS/nixpkgs/commit/3e2a8d53f56b9757c86f7aa9f1b987407fee6ca8) | `python39Packages.spectral-cube: fix version number (#158434)`                         |
| [`1c239a1c`](https://github.com/NixOS/nixpkgs/commit/1c239a1c4f4ed444444576827e857b0582cb970d) | `python39Packages.titlecase: fix version number (#158433)`                             |
| [`ff85de6c`](https://github.com/NixOS/nixpkgs/commit/ff85de6ce806a4ef6cb163d7944b51ca84ad434b) | ``plex: remove unused option `managePlugins```                                         |
| [`a1f1e85d`](https://github.com/NixOS/nixpkgs/commit/a1f1e85d30180f23cb77697b9c459785d2fd5fa2) | `top-level/all-packages: remove trailing whitespace`                                   |
| [`0ad434aa`](https://github.com/NixOS/nixpkgs/commit/0ad434aa2c4b81001b1554fa78c64b1c48458e21) | `nodePackages.@uppy/companion: init at 3.1.1`                                          |
| [`64cb9c78`](https://github.com/NixOS/nixpkgs/commit/64cb9c78e14d0ffc9ee627772a972aa4b59bbfd8) | `yggdrasil: 0.4.2 -> 0.4.3`                                                            |
| [`a0e52205`](https://github.com/NixOS/nixpkgs/commit/a0e52205352eae381daaae4b1d38f9c64d20899a) | `mediaelch: 2.8.12 -> 2.8.14`                                                          |
| [`de4b6944`](https://github.com/NixOS/nixpkgs/commit/de4b6944e02c93cae19635fa0c64f7b3aeaba28c) | `gping: add test`                                                                      |
| [`c40dadac`](https://github.com/NixOS/nixpkgs/commit/c40dadac171a05b37a067ee5393b764860d8e76f) | `gping: 1.2.6 -> 1.2.7`                                                                |
| [`fc4a8a2c`](https://github.com/NixOS/nixpkgs/commit/fc4a8a2c35d0cf19426cdd44a0bd1ba7a23f5fd3) | `gitea: 1.16.0 -> 1.16.1`                                                              |
| [`d9b2a0cf`](https://github.com/NixOS/nixpkgs/commit/d9b2a0cf0e7ebcb8bdf02e2ced833bf8ea840149) | `dbeaver: 21.3.3 -> 21.3.4`                                                            |
| [`97e6067d`](https://github.com/NixOS/nixpkgs/commit/97e6067dd9d2b12ac321663d08ea603de7c345da) | `vscode-extensions.davidanson.vscode-markdownlint: 0.45.0 -> 0.46.0`                   |
| [`956f2820`](https://github.com/NixOS/nixpkgs/commit/956f28202fb67c76cba159cdbeddab8401a7148c) | `vscode-extensions.streetsidesoftware.code-spell-checker: 2.1.4 -> 2.1.5`              |
| [`c53cdc07`](https://github.com/NixOS/nixpkgs/commit/c53cdc07d07f028bdf0c7e9f74a3aa12c5397665) | `vscode-extensions.stkb.rewrap: 1.16.0 -> 1.16.1`                                      |
| [`43f21830`](https://github.com/NixOS/nixpkgs/commit/43f218304096ecc95dd7c182319631b8a72be7e1) | `python310Packages.icmplib: 3.0.2 -> 3.0.3`                                            |
| [`f7284233`](https://github.com/NixOS/nixpkgs/commit/f7284233f495a4e53133046bcb2f892c0fc7c2ed) | `terraform-providers: update 2022-02-07`                                               |
| [`ca656864`](https://github.com/NixOS/nixpkgs/commit/ca6568648fbcbfd917b3ac11469ce891c6337da6) | `python310Packages.pynetbox: 6.5.0 -> 6.6.0`                                           |
| [`c9e7ed67`](https://github.com/NixOS/nixpkgs/commit/c9e7ed676eb5378b11211c06415f6840cd063332) | `python310Packages.pypinyin: 0.44.0 -> 0.45.0`                                         |
| [`2fb3a86e`](https://github.com/NixOS/nixpkgs/commit/2fb3a86e5039dc71f319b0e84a0050645172335f) | `vdr: 2.6.0 -> 2.6.1`                                                                  |
| [`9bc1ce47`](https://github.com/NixOS/nixpkgs/commit/9bc1ce476ca794f05604c3984ced89ffe6c9a525) | `python39Packages.folium: fix version number, run tests, cleanups`                     |
| [`126ff454`](https://github.com/NixOS/nixpkgs/commit/126ff454d4904d53f1377f8cb0485e7b6d372050) | `python39Packages.tmb: fix version number`                                             |
| [`97d005f6`](https://github.com/NixOS/nixpkgs/commit/97d005f6dfe63e63f983e4bc5300e93706a36730) | `python39Packages.twentemilieu: fix version number`                                    |
| [`7d7a5249`](https://github.com/NixOS/nixpkgs/commit/7d7a5249d4e489c755e930bbf6879c53b1a4fb07) | `python39Packages.versiontag: fix version not being set`                               |
| [`8edb8ead`](https://github.com/NixOS/nixpkgs/commit/8edb8eadebebf4005b06a98bcc3f79dcd3c686fd) | `python39Packages.p1monitor: enable tests, fix version number`                         |
| [`9e096216`](https://github.com/NixOS/nixpkgs/commit/9e0962169756f13fd5d0d8b13cc535e0fbe8bfa7) | `python39Packages.waitress-django: update meta, set version to 1.0.0, add maintainer`  |
| [`215002fb`](https://github.com/NixOS/nixpkgs/commit/215002fb9f1fdf96fdb73506225044eb6d5da7ca) | `terraform-providers: update scripts`                                                  |
| [`743ea6e7`](https://github.com/NixOS/nixpkgs/commit/743ea6e70dc2cfc6cc4d4428e91cd3b5ae4820ac) | `river: 0.1.2 -> 0.1.3`                                                                |
| [`66ca0558`](https://github.com/NixOS/nixpkgs/commit/66ca0558df814b421fa1df5a76f4044a98700ef5) | `afterburn: 5.1.0 -> 5.2.0`                                                            |
| [`70791bb1`](https://github.com/NixOS/nixpkgs/commit/70791bb1009114158b9fc658421ac9f61d64d24e) | `dvdisaster: 0.79.5 -> 0.79.9`                                                         |
| [`08e32304`](https://github.com/NixOS/nixpkgs/commit/08e32304d7b9a9e974560d63b18d4c3e878029e0) | `python310Packages.sagemaker: 2.74.0 -> 2.75.0`                                        |
| [`f1c18916`](https://github.com/NixOS/nixpkgs/commit/f1c18916780890496056cf7eb2df7a0097673908) | `python3Packages.garminconnect-aio: disable on older Python releases`                  |
| [`08f41c95`](https://github.com/NixOS/nixpkgs/commit/08f41c95f255e01c3dfe46d493b81af04560ed68) | `python3Packages.garminconnect: 0.1.13 -> 0.1.44`                                      |
| [`915c27b7`](https://github.com/NixOS/nixpkgs/commit/915c27b71b771ae41715198dca801c1eb6088862) | `python3Packages.garminconnect: rename`                                                |
| [`412a82d0`](https://github.com/NixOS/nixpkgs/commit/412a82d048028681f64d72ec492c13fb60d387ac) | `python3Packages.garminconnect-ha: add format`                                         |
| [`4d99d069`](https://github.com/NixOS/nixpkgs/commit/4d99d0694d86905646aa38ebd7675ddc05ee6216) | `vivaldi: 5.0.2497.32-1 -> 5.0.2497.51-1`                                              |
| [`d8014394`](https://github.com/NixOS/nixpkgs/commit/d80143948014db283042a902e26ee18029f2b897) | `croc: 9.5.0 -> 9.5.1`                                                                 |
| [`42511893`](https://github.com/NixOS/nixpkgs/commit/4251189327aaaa8733dfce6cd40544531f918c26) | `lite-xl: 2.0.4 -> 2.0.5`                                                              |
| [`cf55578b`](https://github.com/NixOS/nixpkgs/commit/cf55578b76572dd26a2bbbedcf8def7a73946dbe) | `libsForQt5.bismuth: 2.2.0 -> 2.3.0`                                                   |
| [`b950e4af`](https://github.com/NixOS/nixpkgs/commit/b950e4afa22b77f15aae24474a4dfd58985ecd20) | `sope: 5.5.0 -> 5.5.1`                                                                 |
| [`963cb6d9`](https://github.com/NixOS/nixpkgs/commit/963cb6d9e53db57f5ea5d82ae58b7ca81a699223) | `rss-bridge: 2021-04-25 -> 2022-01-20`                                                 |
| [`6589dec4`](https://github.com/NixOS/nixpkgs/commit/6589dec4588181f795c898055af073a51596b7af) | `python310Packages.vispy: 0.9.4 -> 0.9.6`                                              |
| [`b6e19348`](https://github.com/NixOS/nixpkgs/commit/b6e193485a42cf1cbeb8b1776130c234df65f6ce) | `python310Packages.scikit-fmm: 2021.10.29 -> 2022.2.2`                                 |
| [`bb2db452`](https://github.com/NixOS/nixpkgs/commit/bb2db4526ebebbf7c2e6613d7c5de00e98d7c105) | `python39Packages.gehomesdk: 0.4.22 -> 0.4.23`                                         |
| [`e538c3a5`](https://github.com/NixOS/nixpkgs/commit/e538c3a50f20e23a111d6e27e6e0db7fecafe8a7) | `rpi-imager: 1.6.2 -> 1.7.1`                                                           |
| [`495b80ea`](https://github.com/NixOS/nixpkgs/commit/495b80ea2c2d41e6820cc5c6239a3d7cc43ed84d) | `wordpress: 5.8.3 -> 5.9`                                                              |
| [`64b39305`](https://github.com/NixOS/nixpkgs/commit/64b39305ae26c269c9afcd17dd1463605878dbfe) | `prometheus-redis-exporter: 1.34.1 -> 1.35.0`                                          |
| [`aa2654f9`](https://github.com/NixOS/nixpkgs/commit/aa2654f9dfb2413558e3550978c84bc478b8c912) | `gwtwidgets: remove`                                                                   |
| [`017c4d20`](https://github.com/NixOS/nixpkgs/commit/017c4d207c7f4149f8b631e0f0d6760295d0b8e8) | `gwtdragdrop: remove`                                                                  |
| [`f57aa479`](https://github.com/NixOS/nixpkgs/commit/f57aa4795c2d63d178fe9cf5e664cd655d47ceba) | `iops: remove`                                                                         |
| [`82da8aaa`](https://github.com/NixOS/nixpkgs/commit/82da8aaa53481a202158e357fbfab0c1c4260956) | `heme: remove`                                                                         |
| [`c1ef1d8f`](https://github.com/NixOS/nixpkgs/commit/c1ef1d8f9b1ec61bbdc353b7a5458e9d546a6587) | `idrisPackages.protobuf: remove`                                                       |
| [`1d5453ca`](https://github.com/NixOS/nixpkgs/commit/1d5453ca8ccbdf2d30749d3c68c2cb92fe94031e) | `gpgstats: remove`                                                                     |
| [`cea0fa3f`](https://github.com/NixOS/nixpkgs/commit/cea0fa3f7d1037f9c43c8547fce20d0f2d570566) | `encryptr: remove`                                                                     |
| [`48b409d8`](https://github.com/NixOS/nixpkgs/commit/48b409d8e2b6339edb655a01ebfee5edd0d948f0) | `deisctl: remove`                                                                      |
| [`0764d56e`](https://github.com/NixOS/nixpkgs/commit/0764d56ef309995921bfc9f1bb3b91a4d50bbd22) | `deis: remove`                                                                         |
| [`98e91ccc`](https://github.com/NixOS/nixpkgs/commit/98e91ccc56ebb9b80026a875aefe90823e211b38) | `python3Packages.asyncio-dgram: 2.1.1 -> 2.1.2`                                        |
| [`b8b1f359`](https://github.com/NixOS/nixpkgs/commit/b8b1f35977c0d1a7a205d6aa6b575fd2e00d03f7) | `python3Packages.plugwise: 0.16.1 -> 0.16.2`                                           |
| [`4469918d`](https://github.com/NixOS/nixpkgs/commit/4469918dffbdbe0d326de7af7df18367802b25ac) | `dnscontrol: 3.13.1 -> 3.14.0`                                                         |
| [`9b5b9101`](https://github.com/NixOS/nixpkgs/commit/9b5b9101fabcaa4d7f340d3ad0d9f66d884346e4) | `maintainers: add nelsonjeppesen`                                                      |
| [`aae194d8`](https://github.com/NixOS/nixpkgs/commit/aae194d8b236bd41c94cdcc0b85f01a2cc9f783d) | `kitty-themes: init at unstable-2022-02-03`                                            |
| [`fd6d3683`](https://github.com/NixOS/nixpkgs/commit/fd6d3683317012d5fdf69df46e3e2d0db841fd51) | `yq-go: 4.18.1 -> 4.19.1`                                                              |
| [`71f2b10b`](https://github.com/NixOS/nixpkgs/commit/71f2b10b6fba723c33affd1bb9b615b7e1f348df) | `python39Packages.python-manilaclient: 3.1.0 -> 3.2.0`                                 |
| [`2cddc19d`](https://github.com/NixOS/nixpkgs/commit/2cddc19d39b0ff4d90d511230cd28c28525ab9b1) | `Revert "python310Packages.oslo-context: 3.4.0 -> 4.0.0"`                              |
| [`9334f6f1`](https://github.com/NixOS/nixpkgs/commit/9334f6f1daf88663f4e3d69bb876649abc513dfd) | `haskellPackages: mark builds failing on hydra as broken`                              |
| [`b8654c7c`](https://github.com/NixOS/nixpkgs/commit/b8654c7cd2afde041d1d84f69e75cc0e7bb61efc) | `wifite: 2.5.7 -> 2.6.0`                                                               |
| [`7ebca5e8`](https://github.com/NixOS/nixpkgs/commit/7ebca5e87ba29e18026e9cfca1c58c66e3c620aa) | `haskellPackages: mark builds failing on hydra as broken`                              |
| [`c0217caf`](https://github.com/NixOS/nixpkgs/commit/c0217caf80718e770cb1ec2fc1f9c4bc4c159158) | `cl-wordle: init at 0.1.2`                                                             |
| [`6ad0e10d`](https://github.com/NixOS/nixpkgs/commit/6ad0e10dd350c8ffd1fd35d787f5b5dce95e59f5) | `coq: add meta.mainProgram`                                                            |
| [`938a2af3`](https://github.com/NixOS/nixpkgs/commit/938a2af392b56c7dc3c7e7eafa7d0de9873acc9d) | `checkov: 2.0.793 -> 2.0.795`                                                          |
| [`9dcf20f2`](https://github.com/NixOS/nixpkgs/commit/9dcf20f284561d15869f4fb786a58fc8cfde2db7) | `flutter: 2.8.0 -> 2.10.0`                                                             |
| [`7b937e91`](https://github.com/NixOS/nixpkgs/commit/7b937e9152989c6f6e8c7a44f014cbc84aed640f) | `rxvt-unicode-emoji: init as variant of rxvt-unicode, with wide glyph (emoji) support` |
| [`814b63e9`](https://github.com/NixOS/nixpkgs/commit/814b63e93e2aac4e9f4116735fb290bad4756ed8) | `treewide: rename name to pname&version`                                               |
| [`97f809dc`](https://github.com/NixOS/nixpkgs/commit/97f809dc87f74ef51e4f0482328f7db617db91ef) | `nixos/ipfs: use ipfs config replace`                                                  |
| [`6308679d`](https://github.com/NixOS/nixpkgs/commit/6308679d28886b8c0d0377b4227a012ca4ca6fdc) | `ocamlPackages.cairo2: fix build on aarch64-darwin`                                    |
| [`03c27d12`](https://github.com/NixOS/nixpkgs/commit/03c27d129e48476f0d14943d77efaacf40331f1c) | `python3Packages.pytradfri: 8.0.1 -> 9.0.0`                                            |
| [`6ea5380b`](https://github.com/NixOS/nixpkgs/commit/6ea5380b4eff908f3b2a3eff1dc98f74ff45f1da) | `mpris-scrobbler: mark as broken on darwin`                                            |
| [`c7e17313`](https://github.com/NixOS/nixpkgs/commit/c7e17313e155ea544b80ae6ca41988f8fd93718f) | `python3Packages.intellifire4py: 0.5 -> 0.7.3`                                         |
| [`dc28299c`](https://github.com/NixOS/nixpkgs/commit/dc28299c85b35b1ef3a45cb1222dc5fc93a3bad7) | `irssi: enable parallel building`                                                      |
| [`5facd430`](https://github.com/NixOS/nixpkgs/commit/5facd430d4aedae75f8c4027fa62624225b9e752) | `slack: aarch64 darwin support and updater`                                            |
| [`be83d5bb`](https://github.com/NixOS/nixpkgs/commit/be83d5bb389dc3093b10c7f14530b43e35ede3ae) | `apache-beam: mark as broken on 3.10`                                                  |
| [`ca5bf5bd`](https://github.com/NixOS/nixpkgs/commit/ca5bf5bd262cc29417fa1b871f34487afdc9d042) | `apache-beam: patch out pyarrow constraint`                                            |
| [`c1998338`](https://github.com/NixOS/nixpkgs/commit/c1998338b23f1b8713ebaf4ca82e521fde66b3ff) | `arrow-cpp: 6.0.1 -> 7.0.0`                                                            |
| [`974f984e`](https://github.com/NixOS/nixpkgs/commit/974f984e56c18b55aca55a6609c69684a6cee330) | `python3Packages.oscrypto: disable tests on darwin`                                    |
| [`4c6d4928`](https://github.com/NixOS/nixpkgs/commit/4c6d49282b1d63de6a2977a1d3ed97656cb58963) | `cryptopp: add an option to build with OpenMP`                                         |
| [`4ec7d050`](https://github.com/NixOS/nixpkgs/commit/4ec7d05099f639e8370ed3506d1a7b17af1ceb6b) | `google-chrome: passthrough CHROME_WRAPPER environment variable`                       |
| [`a52aae68`](https://github.com/NixOS/nixpkgs/commit/a52aae6868d4a1d1e5447aa45de6562bfc71b903) | `tauon: install desktop file and icon`                                                 |
| [`c53d2b9c`](https://github.com/NixOS/nixpkgs/commit/c53d2b9c3ee491bfbbf70eaa784c74a7ec046e7d) | `tauon: 6.7.1 -> 7.0.1`                                                                |
| [`4a07f242`](https://github.com/NixOS/nixpkgs/commit/4a07f24237fc3ac627d8bc7b230537c9440f7840) | `picom-next: unstable-2021-11-19 -> unstable-2022-02-05`                               |
| [`6afd9574`](https://github.com/NixOS/nixpkgs/commit/6afd95743ef045bf5d5a22bc62ce13bdbc6131b3) | `picom: 8.2 -> 9`                                                                      |
| [`3302c41f`](https://github.com/NixOS/nixpkgs/commit/3302c41f7f3104042b53393630d0b8577fbb5bd5) | `haskell-language-server: Disable flaky tests for some plugins`                        |
| [`df68f3a7`](https://github.com/NixOS/nixpkgs/commit/df68f3a71e458fb6b1c461d4278554acd8e32ec4) | `scrot: clean up`                                                                      |
| [`c49d149c`](https://github.com/NixOS/nixpkgs/commit/c49d149c82a5e98779c5e1ea18808e77d13ba339) | `python3Packages.pywizlight: 0.4.16 -> 0.5`                                            |
| [`c2e6d4ab`](https://github.com/NixOS/nixpkgs/commit/c2e6d4abf0c42f52fce605b89f9888fd0836513c) | `python3Packages.minikerberos: 0.2.16 -> 0.2.17`                                       |
| [`c87e86df`](https://github.com/NixOS/nixpkgs/commit/c87e86dfeb9d0fa6b7462e02f58f8876b9d8e20c) | `scalapack: allow to build with ILP64 interface`                                       |
| [`1254665d`](https://github.com/NixOS/nixpkgs/commit/1254665d5abed9702390b2f0cfa7b89cc8638b75) | `python3Packages.pg8000: 1.23.0 -> 1.24.0`                                             |
| [`2680769a`](https://github.com/NixOS/nixpkgs/commit/2680769ae5e3e64dc752850be71aa57c1436ea1c) | `python3Packages.soco: 0.26.1 -> 0.26.2`                                               |
| [`6bc3ad97`](https://github.com/NixOS/nixpkgs/commit/6bc3ad97a4e50a7f8e134f32ed84ec07c5a1c41e) | `python3Packages.asysocks: 0.1.6 -> 0.1.7`                                             |
| [`fb4e2eaa`](https://github.com/NixOS/nixpkgs/commit/fb4e2eaa057aebdce0918bb7ab21a1ef1193df26) | `python310Packages.dj-email-url: 1.0.4 -> 1.0.5`                                       |
| [`5cf6b248`](https://github.com/NixOS/nixpkgs/commit/5cf6b24884b2ec82a6adc0be73aeb379ce570f1b) | `python3Packages.xknx: 0.19.1 -> 0.19.2`                                               |
| [`eca8a5d6`](https://github.com/NixOS/nixpkgs/commit/eca8a5d6941626d43e05d73635e915a0d3f482ce) | `pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix: manual fixup`      |
| [`8b36faa2`](https://github.com/NixOS/nixpkgs/commit/8b36faa20bc86ec9b278c3ca741b94d7fb8b3271) | `elpa-packages 2022-02-06`                                                             |
| [`88a7c0e3`](https://github.com/NixOS/nixpkgs/commit/88a7c0e327772fbac71e5c67d3fbad6b8709d092) | `melpa-packages 2022-02-06`                                                            |
| [`12b90a49`](https://github.com/NixOS/nixpkgs/commit/12b90a49fb708bacc883a839db9d449c8c97813e) | `nongnu-packages 2022-02-06`                                                           |
| [`77a5a7a3`](https://github.com/NixOS/nixpkgs/commit/77a5a7a308cbaa46e1d0abfe43fd488cb665cc10) | `multimc: add link to pr in aliases`                                                   |
| [`09f582a4`](https://github.com/NixOS/nixpkgs/commit/09f582a45be72105bcf780a2dc28ce7199b39eaf) | `cargo-spellcheck: 0.9.6 -> 0.10.1`                                                    |
| [`0084254a`](https://github.com/NixOS/nixpkgs/commit/0084254ad147fbf4b2ba0e63746449089117cc8a) | `python3Packages.pysdl2: 0.9.9 -> 0.9.11`                                              |
| [`b796dfa2`](https://github.com/NixOS/nixpkgs/commit/b796dfa2a6f156afa24c7a00644404bc159aa58f) | `scrot: drop dependency on giblib`                                                     |
| [`85325234`](https://github.com/NixOS/nixpkgs/commit/85325234ee2da4b30297a3ff23ba111cc659cb7e) | `fakeroot: 1.23 -> 1.27`                                                               |
| [`cc73f310`](https://github.com/NixOS/nixpkgs/commit/cc73f310fa7c8949c8270e585a24f265c07e1c74) | `taskwarrior-tui: 0.13.35 -> 0.18.5`                                                   |
| [`6f2cabd8`](https://github.com/NixOS/nixpkgs/commit/6f2cabd82c824a18d8b9f0370fa72733bf64b01f) | `lookatme: init at 2.3.2`                                                              |
| [`36b1dedd`](https://github.com/NixOS/nixpkgs/commit/36b1dedddd1b63d83129856ea52f0208f99c672c) | `firejail: 0.9.66 -> 0.9.68`                                                           |
| [`83259c68`](https://github.com/NixOS/nixpkgs/commit/83259c68148ffc8dd60643f2ae8ae02944cd52c6) | `maintainers: add ameer`                                                               |
| [`4e68d69a`](https://github.com/NixOS/nixpkgs/commit/4e68d69af94234cc164880a0fe14b03c2283c9d5) | `celt: update homepage`                                                                |
| [`da27e1dd`](https://github.com/NixOS/nixpkgs/commit/da27e1dd8a89dd88d2aa04cf66d7a6bc2a8be6ac) | `idnkit: update homepage`                                                              |
| [`0532c0fc`](https://github.com/NixOS/nixpkgs/commit/0532c0fcd8352f0d88b50dcef9e839669894f833) | `icewm: update homepage`                                                               |
| [`d2ab0390`](https://github.com/NixOS/nixpkgs/commit/d2ab0390f072991160c43ada4875576c8eaa5bc8) | `hyperledger-fabric: update homepage`                                                  |
| [`a4ca166b`](https://github.com/NixOS/nixpkgs/commit/a4ca166bb67dd28e9d252f9e5346c58ebceb7d6d) | `hybridreverb2: update homepage`                                                       |