### PR TITLE
chore(flake/poetry2nix): `d3dc8d28` -> `69cc39aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1644294697,
-        "narHash": "sha256-+XHCt4Oyyxwib+sZNlM/iUt7VVLgqpKZWqJwegO9+IA=",
+        "lastModified": 1645139622,
+        "narHash": "sha256-ahpapiZ59asavSgMqlvRoEL8eApsYQ9Xp3r5tiTbSTY=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "d3dc8d28f29cb56ed861585ed3ec393b7d859261",
+        "rev": "69cc39aa3b84c57eebc202b591c5876429e569a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                    | Commit Message                                         |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`f36a1aae`](https://github.com/nix-community/poetry2nix/commit/f36a1aaea3198a845e2b48b7a5e71faba52ced45) | `overrides.pymediainfo: patch libmediainfo paths`      |
| [`b92a0073`](https://github.com/nix-community/poetry2nix/commit/b92a007388508dff2b24621821a3e76a7f4057f8) | `overrides.pikepdf: add qpdf and pybind11 buildInputs` |
| [`02926081`](https://github.com/nix-community/poetry2nix/commit/029260810c585af62873752d7c3a186e0db3e286) | `overrides.python-magic: patch libmagic path`          |