### PR TITLE
chore(flake/poetry2nix): `69cc39aa` -> `2ef1c4d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1645139622,
-        "narHash": "sha256-ahpapiZ59asavSgMqlvRoEL8eApsYQ9Xp3r5tiTbSTY=",
+        "lastModified": 1648737046,
+        "narHash": "sha256-h2yXUTsna8cK3XyITZYhkcAn9tSDYwJXF8+b4EOf1F0=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "69cc39aa3b84c57eebc202b591c5876429e569a7",
+        "rev": "2ef1c4d8c0d8bf4a8401d0abceee97cfe0761c3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                    | Commit Message                                                              |
| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`53b790e5`](https://github.com/nix-community/poetry2nix/commit/53b790e5e35506c1232f7dd4c935ae690849e916) | `poetry: 1.1.12 -> 1.1.13`                                                  |
| [`77355835`](https://github.com/nix-community/poetry2nix/commit/7735583527afc000b70759b93c94d35cdc24f2d3) | `overrides.cryptography: Add 36.0.2 hash`                                   |
| [`40e361d5`](https://github.com/nix-community/poetry2nix/commit/40e361d53beb1cae38d038a23460313964ea447f) | `poetry: Rewrite updater in Python`                                         |
| [`0d98f350`](https://github.com/nix-community/poetry2nix/commit/0d98f35040bca570119c4f75305d82b59c54756f) | `Bump nixpkgs (2022-03-31)`                                                 |
| [`8249fb2c`](https://github.com/nix-community/poetry2nix/commit/8249fb2c6e46f82d47b52a42e0882faeb620bee0) | `Remove flake.lock and gitignore it`                                        |
| [`000d8ddd`](https://github.com/nix-community/poetry2nix/commit/000d8dddb833d91f2cc2d4aadca3ae083fc3396c) | `overrides.cryptography: Prefer wheel if we don't have a pinned cargo hash` |
| [`70fcc2b0`](https://github.com/nix-community/poetry2nix/commit/70fcc2b05b4dd2344ca51808d27338884e77d411) | `overrides: add py-solc-x`                                                  |
| [`caad636c`](https://github.com/nix-community/poetry2nix/commit/caad636c27e63b378e5dce2db9df21174892f299) | `overrides: add coincurve`                                                  |
| [`40e199d9`](https://github.com/nix-community/poetry2nix/commit/40e199d9d29f0cd3e3f30ba9b7e770e3533fc0bc) | `Disable PEP 600 test on MacOS`                                             |
| [`d687e93c`](https://github.com/nix-community/poetry2nix/commit/d687e93cb98f0c503446e6b8c38adb76d01e8ea8) | `Add test for PEP 600`                                                      |
| [`8bee2d9d`](https://github.com/nix-community/poetry2nix/commit/8bee2d9d83ac4a3c547a71aa6769249de0496b19) | `Do not include the build system in nativeBuildInputs for wheels`           |
| [`87350abf`](https://github.com/nix-community/poetry2nix/commit/87350abfc814c271e5cf7ed8dcfc79920b500965) | `Add support for PEP 600`                                                   |
| [`9a95ca82`](https://github.com/nix-community/poetry2nix/commit/9a95ca8283add67472629420b319c821024467d0) | `Match multiple platform tags when selecting wheels`                        |
| [`fe368a40`](https://github.com/nix-community/poetry2nix/commit/fe368a40d292462a80cc5a7ba2f8a485b8b90aeb) | `Cleanup lib.strings member references`                                     |
| [`3bf852b5`](https://github.com/nix-community/poetry2nix/commit/3bf852b542fb420b596df0daf0635bed4ec5cf04) | `overrides.ccxt: patch path to README`                                      |
| [`d124e731`](https://github.com/nix-community/poetry2nix/commit/d124e7312b7deb506b7c92e3bfbdf3203fd951a8) | `Fix mypy 0.940+`                                                           |
| [`3d10fcb4`](https://github.com/nix-community/poetry2nix/commit/3d10fcb41f35e29f3732f5305381fd708280b423) | `build-systems: add pyopencl`                                               |
| [`4e419b6e`](https://github.com/nix-community/poetry2nix/commit/4e419b6e20644b9c7666f647f6b8bdea860a0959) | `build-systems: add pytest-profiling`                                       |
| [`761565ce`](https://github.com/nix-community/poetry2nix/commit/761565ced3bc1a2f2d1bb67401f22996c6944533) | `chore(build-systems/mkdocs-autorefs): add pdm-pep517 to nativeBuildInputs` |
| [`b080a46f`](https://github.com/nix-community/poetry2nix/commit/b080a46f7bdf9c696937f725cb6cc45bd129da80) | `lz4: add pkgconfig`                                                        |
| [`831957d9`](https://github.com/nix-community/poetry2nix/commit/831957d9f6d08149bc341b2b833d185b7ce7cd66) | `build-systems: add mkdocs-gen-files`                                       |
| [`84f0a036`](https://github.com/nix-community/poetry2nix/commit/84f0a036faa2ba317de9dfd725663cd3eb18c851) | `chore: add mkdocs-literate-nav to build systems`                           |
| [`873b0f8a`](https://github.com/nix-community/poetry2nix/commit/873b0f8a19ae9b68222d610dafacc3c3d3783b6e) | `chore: add duckdb and duckdb-engine to build-systems.json`                 |