### PR TITLE
chore(flake/utils): `0f8662f1` -> `a4b154eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1648297722,
-        "narHash": "sha256-W+qlPsiZd8F3XkzXOzAoR+mpFqzm3ekQkJNa+PIh1BQ=",
+        "lastModified": 1649676176,
+        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "0f8662f1319ad6abf89b3380dd2722369fc51ade",
+        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                       |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`a4b154eb`](https://github.com/numtide/flake-utils/commit/a4b154ebbdc88c8498a5c7b01589addc9e9cb678) | `Bump cachix/install-nix-action from 16 to 17 (#58)` |