### PR TITLE
chore(flake/poetry2nix): `2ef1c4d8` -> `ece2a416`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1648737046,
-        "narHash": "sha256-h2yXUTsna8cK3XyITZYhkcAn9tSDYwJXF8+b4EOf1F0=",
+        "lastModified": 1651165059,
+        "narHash": "sha256-/psJg8NsEa00bVVsXiRUM8yL/qfu05zPZ+jJzm7hRTo=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "2ef1c4d8c0d8bf4a8401d0abceee97cfe0761c3d",
+        "rev": "ece2a41612347a4fe537d8c0a25fe5d8254835bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                    | Commit Message                                                                  |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`639115b8`](https://github.com/nix-community/poetry2nix/commit/639115b897676e00a584372fcfbca2efc3894764) | `overrides.lsassy: Work around upstream missing version constraint in setup.py` |
| [`b742ddd0`](https://github.com/nix-community/poetry2nix/commit/b742ddd0876368fc96aa233c15553a34094aaa47) | `overrides.pysrp: Add poetry-core`                                              |
| [`d3a73e6b`](https://github.com/nix-community/poetry2nix/commit/d3a73e6bc4d6b338cae85f0d8b829845409fa35b) | `overrides.lsassy: Add poetry-core`                                             |
| [`d877c544`](https://github.com/nix-community/poetry2nix/commit/d877c544c8e987507760b473358e81525aea12ec) | `overrides.mkdocs-jupyter: Regeneration caused reordering`                      |
| [`5299c0a3`](https://github.com/nix-community/poetry2nix/commit/5299c0a36ea56c6a2a586aa1bbfc8544b07643a2) | `build-systems: add docstring-parser and pymdown-extensions`                    |
| [`8cfd9802`](https://github.com/nix-community/poetry2nix/commit/8cfd980262181bd3ef15899708ceeb2e3f33958b) | `overrides.platformdirs: Add hatch-vcs`                                         |
| [`ee93bd01`](https://github.com/nix-community/poetry2nix/commit/ee93bd01216cd3a88ce44bebdd33237c1bb1b274) | `fix: add hatchling for platformdirs`                                           |
| [`a811ce77`](https://github.com/nix-community/poetry2nix/commit/a811ce7793fdf60894f587678675ba73fdfb8395) | `build-systems: add more`                                                       |
| [`c13ba702`](https://github.com/nix-community/poetry2nix/commit/c13ba702088ca2d16395227b2c5cae07476599bd) | `Document preferWheels parameter`                                               |
| [`32263beb`](https://github.com/nix-community/poetry2nix/commit/32263bebfeba5f8ef41c3146b71caf221052b69a) | `make soundfile find libsndfile at runtime (#597)`                              |
| [`2291694c`](https://github.com/nix-community/poetry2nix/commit/2291694c6a0e5385cce6dfba6eac32b46fe73d17) | `Used incorrect hash for orjson 3.6.7`                                          |
| [`59ffefbd`](https://github.com/nix-community/poetry2nix/commit/59ffefbd2493f3551d18ff924510e1d579a9d8c3) | `overrides.iso8601: Add poetry-core build system`                               |
| [`a992cb63`](https://github.com/nix-community/poetry2nix/commit/a992cb630b40011289ec3c3a5212c86b82deeec4) | `datadog package and also support for hatchling`                                |
| [`2f3acc2c`](https://github.com/nix-community/poetry2nix/commit/2f3acc2cf23e37fbdf5fa8943050d0d5f9b029a3) | `orjson override`                                                               |
| [`b6bab4e1`](https://github.com/nix-community/poetry2nix/commit/b6bab4e1885d1fb479d292d35d9bebd2e5b555a0) | `overrides: Fix docutils with setuptools >= 60`                                 |
| [`8e267767`](https://github.com/nix-community/poetry2nix/commit/8e267767697134a5570420e723214c39b927642a) | `Remove nix-build-uncached from niv management`                                 |
| [`3b5085d7`](https://github.com/nix-community/poetry2nix/commit/3b5085d74a5719a841f062c31a70a6ef881e33f4) | `Regenerate build-systems.json`                                                 |
| [`b98864a9`](https://github.com/nix-community/poetry2nix/commit/b98864a92138c32d55cfe67d744e2a0c7971571e) | `Bump niv channel`                                                              |
| [`1baca435`](https://github.com/nix-community/poetry2nix/commit/1baca435061d99b13607cc7d8b8fdd69c1d8efce) | `fix: support nullified editablePackageSources in mkPoetryEnv`                  |
| [`aa92ff14`](https://github.com/nix-community/poetry2nix/commit/aa92ff14ffdbac37a632794024a1fdb121b8065f) | `Rerun find build systems script`                                               |
| [`b3a52937`](https://github.com/nix-community/poetry2nix/commit/b3a52937cc310becf86de214d9092d1d0d119394) | `build-systems.json: add pyparsing`                                             |
| [`b85da771`](https://github.com/nix-community/poetry2nix/commit/b85da771bac52484d6624fdf750e1bb61f02a382) | `build-systems.json: add poetry-dynamic-versioning`                             |
| [`5e667bc5`](https://github.com/nix-community/poetry2nix/commit/5e667bc5271b12946e32ea887b3c7c7b0e1d8906) | `Fix infinite recusion in the case where no gitignores are found`               |
| [`1daf54da`](https://github.com/nix-community/poetry2nix/commit/1daf54da67d1c5dfbec032af45a990b89cb411e4) | `fix: avoid infinite recursion while searching for path`                        |
| [`0dd8ba71`](https://github.com/nix-community/poetry2nix/commit/0dd8ba714a8a86ba907ff9c98b48d03ed1cf529b) | `overrides: pillow: Add libxcb libX11 (#587)`                                   |
| [`99c79568`](https://github.com/nix-community/poetry2nix/commit/99c79568352799af09edaeefc858d337e6d9c56f) | `Poetry updater: Add newline to src.json`                                       |
| [`405b05a0`](https://github.com/nix-community/poetry2nix/commit/405b05a0ab648b7753f986252109e85c80c16a5d) | `Bump version to 1.27.1`                                                        |
| [`8fad4533`](https://github.com/nix-community/poetry2nix/commit/8fad45334368bd8c4981c6823e823d4333f1e374) | `Regenerate build-systems.json`                                                 |
| [`e0d2c505`](https://github.com/nix-community/poetry2nix/commit/e0d2c505e7919fb3c293a8d42f53af47a99910a1) | `Bump version to 1.27.0`                                                        |