### PR TITLE
chore(flake/nixpkgs): `10632447` -> `6766fb65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1648673296,
-        "narHash": "sha256-dlQP4/escrnt8vm1WAbWrYeFvYF1F1K3m+9qsUHwL+I=",
+        "lastModified": 1651114127,
+        "narHash": "sha256-/lLC0wkMZkAdA5e1W76SnJzbhfOGDvync3VRHJMtAKk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1063244793d9b2dc3db515ac5b70a85385ec9b10",
+        "rev": "6766fb6503ae1ebebc2a9704c162b2aef351f921",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`6cf368ed`](https://github.com/NixOS/nixpkgs/commit/6cf368ed0e35e71118a35d8896f64e0d00c5161e) | `ocamlPackages.tezos: remove`                                                    |
| [`f26f7a16`](https://github.com/NixOS/nixpkgs/commit/f26f7a16d04c428ea01a7f332f79f5d3c6ae50c8) | `fluxcd: 0.29.3 -> 0.29.4`                                                       |
| [`1248ea16`](https://github.com/NixOS/nixpkgs/commit/1248ea16e1a2009dec2f7a88fba7a77fd77d3a07) | `colmap: fix for cuda11.6/gcc11 (#169623)`                                       |
| [`2da4e4f0`](https://github.com/NixOS/nixpkgs/commit/2da4e4f0e2a00119846206c8ccdf5c4c19e7937b) | `maintainers/wolfangaukang: update email`                                        |
| [`55275617`](https://github.com/NixOS/nixpkgs/commit/552756170ec956492afea924cec0757f413b530e) | `lifeograph: 2.0.2 -> 2.0.3`                                                     |
| [`c476904a`](https://github.com/NixOS/nixpkgs/commit/c476904a78ea4add2a8065f4d68dc0f16a7310d4) | `python310Packages.pyezviz: 0.2.0.7 -> 0.2.0.8`                                  |
| [`c19e9b77`](https://github.com/NixOS/nixpkgs/commit/c19e9b776d79eec39336fc0772272da4759f28d3) | `.github/workflows/update-terraform-providers.yml: minor fixes`                  |
| [`17781f77`](https://github.com/NixOS/nixpkgs/commit/17781f77f5248aa2a05d4f2449700728a2d44716) | `yt-dlp-light: disable atomicparsley and rtmp`                                   |
| [`14dd7b52`](https://github.com/NixOS/nixpkgs/commit/14dd7b52b152ae1afaeada2c7b53c686e5d11f43) | `yt-dlp: make atomicparsley optional`                                            |
| [`713b41d2`](https://github.com/NixOS/nixpkgs/commit/713b41d22ae7008cc5596c58f79459a23b3e9471) | `ntfy-sh: 1.20.0 -> 1.21.2`                                                      |
| [`b33688fe`](https://github.com/NixOS/nixpkgs/commit/b33688feefdf77b5aef63e9324313b52fe11ed53) | `checkov: 2.0.1085 -> 2.0.1088`                                                  |
| [`c06162db`](https://github.com/NixOS/nixpkgs/commit/c06162dbf13624a0cdc771eeb7473a13d7c5a01e) | `oh-my-zsh: 2022-04-22 -> 2022-04-24 (#170382)`                                  |
| [`65fb2b12`](https://github.com/NixOS/nixpkgs/commit/65fb2b12e9c2259656e0152fbe0686ac92f392ea) | `yakuake: set outputs to reduce runtime closure`                                 |
| [`538ace28`](https://github.com/NixOS/nixpkgs/commit/538ace2858d0d95d85263f8f3d652a83baa3764f) | `okteta: set outputs to reduce runtime closure`                                  |
| [`535997fa`](https://github.com/NixOS/nixpkgs/commit/535997fa52e1a407bf5037ff974bbe2dba0e5942) | `lib/strings: fix quoting of example`                                            |
| [`a231ab10`](https://github.com/NixOS/nixpkgs/commit/a231ab1096537dd4f4852adec84ed7ebfc0e6c39) | `coqPackages.coqtail-math: 20201124 → 8.14`                                      |
| [`30bb1586`](https://github.com/NixOS/nixpkgs/commit/30bb15868a72c74358a49f13409caf871cf1bb35) | `scalapack: fix build with gcc-10`                                               |
| [`9abec5d3`](https://github.com/NixOS/nixpkgs/commit/9abec5d3d18954fa4f17ff97947a25920744d5b8) | `python310Packages.fastavro: 1.4.10 -> 1.4.11`                                   |
| [`0094e13d`](https://github.com/NixOS/nixpkgs/commit/0094e13d47837595c4012f9adbca27a99f55bb54) | `fulcio: 0.3.0 -> 0.4.0`                                                         |
| [`b2a98c56`](https://github.com/NixOS/nixpkgs/commit/b2a98c56801bbe1a1c1782f4e04cff46f953c5df) | `cosign: 1.7.2 -> 1.8.0`                                                         |
| [`2b5039f4`](https://github.com/NixOS/nixpkgs/commit/2b5039f40f6783e310a5764d813c35db6ec21b73) | `maintainers: add ckie matrix`                                                   |
| [`119ce9d9`](https://github.com/NixOS/nixpkgs/commit/119ce9d9d52fee0ffe5e54c2c3ebc25e4f9f60a1) | `ginkgo: 2.1.3 -> 2.1.4`                                                         |
| [`226bc996`](https://github.com/NixOS/nixpkgs/commit/226bc996597407aed9fced101234962a542d6bfd) | `lib/strings: add toShellVars`                                                   |
| [`3a33b00f`](https://github.com/NixOS/nixpkgs/commit/3a33b00fd8d806c3384b10fac8c2c407e47b79d0) | `prisma-engines: 3.12.0 -> 3.13.0`                                               |
| [`b536cc5b`](https://github.com/NixOS/nixpkgs/commit/b536cc5b253c852e39f42e73fedab501aadc1f27) | `stripe-cli: 1.8.4 -> 1.8.8`                                                     |
| [`e1aa8bfb`](https://github.com/NixOS/nixpkgs/commit/e1aa8bfbe808c84d405dc90087d39cd28569030e) | `nerdctl: 0.18.0 -> 0.19.0`                                                      |
| [`47194d8d`](https://github.com/NixOS/nixpkgs/commit/47194d8ddb68a947b56b5bf7b2e4fe0a55598096) | `davinci-resolve: dont use a alias`                                              |
| [`ad1f6eb1`](https://github.com/NixOS/nixpkgs/commit/ad1f6eb12208a2c3e928f4a89ec5b5b3798e226b) | `tun2socks: init at 2.4.1`                                                       |
| [`73468fbc`](https://github.com/NixOS/nixpkgs/commit/73468fbcf74e06a9ed1d1a32a3245d2fc1c395ca) | `sosreport: init at 4.3`                                                         |
| [`1d3f046e`](https://github.com/NixOS/nixpkgs/commit/1d3f046e9071e8797a5c9213eeefbd0111255243) | `snazy: init at 0.4.0`                                                           |
| [`9e99a109`](https://github.com/NixOS/nixpkgs/commit/9e99a1093bf3f7e9ada150d8986e3ecf81559f50) | `python310Packages.bsblan: remove coverage part`                                 |
| [`23565236`](https://github.com/NixOS/nixpkgs/commit/2356523666596118bd11890522f70dc9ca478b22) | `python310Packages.casbin: 1.15.5 -> 1.16.0`                                     |
| [`ccd5b966`](https://github.com/NixOS/nixpkgs/commit/ccd5b966a0837593011880a99aa66dad38f09aec) | `python310Packages.srvlookup: switch to pytestCheckHook`                         |
| [`1855dc55`](https://github.com/NixOS/nixpkgs/commit/1855dc550ff2967185b15fffbf69b79e8f2c6228) | `python310Packages.requests-http-signature: 0.2.0 -> 0.7.1`                      |
| [`a98e1af2`](https://github.com/NixOS/nixpkgs/commit/a98e1af265e6c2dd57ddf090c13c0d0da4b04374) | `python310Packages.http-message-signatures: init at 0.4.3`                       |
| [`e7b60a8b`](https://github.com/NixOS/nixpkgs/commit/e7b60a8b8194357c4f35f2fa490860d3e7400608) | `python310Packages.http-sfv: init at 0.9.5`                                      |
| [`b3ae9c52`](https://github.com/NixOS/nixpkgs/commit/b3ae9c52d493402a7edac283f499a39e37de3b6e) | `crun: 1.4.4 -> 1.4.5`                                                           |
| [`a5f876f6`](https://github.com/NixOS/nixpkgs/commit/a5f876f6d184a11597d6ac908036868ba8b4ea0e) | `lima: 0.9.2 -> 0.10.0`                                                          |
| [`5faa38e9`](https://github.com/NixOS/nixpkgs/commit/5faa38e9de6202ff75183d33f07698f9385f7c13) | `python310Packages.srvlookup: 2.0.0 -> 3.0.0`                                    |
| [`43a925d5`](https://github.com/NixOS/nixpkgs/commit/43a925d56672b4e43d12848efc85d1a4c6a72a32) | `megacmd: 1.5.0 → 1.5.0c`                                                        |
| [`1797f919`](https://github.com/NixOS/nixpkgs/commit/1797f919c30c91a61e9c4e513fef2bf3bfe32b6a) | `python310Packages.limnoria: 2022.3.17 -> 2022.4.22`                             |
| [`f4b4c51f`](https://github.com/NixOS/nixpkgs/commit/f4b4c51fcee3370da89da71d2f22db4b92dc34c1) | `ikill: init at 1.5.0`                                                           |
| [`5f4d887d`](https://github.com/NixOS/nixpkgs/commit/5f4d887d260004c622954d491b1f9c1616ff8796) | `python310Packages.ansible: 5.6.0 -> 5.7.0`                                      |
| [`8d1e5a3a`](https://github.com/NixOS/nixpkgs/commit/8d1e5a3a6802ea293a5c5f4bcc0c8fb2aacfae72) | `libslirp: 4.6.1 -> 4.7.0`                                                       |
| [`0c00267c`](https://github.com/NixOS/nixpkgs/commit/0c00267cd1d56dc5d0eae3458029aa86fbc467c2) | `containerd: 1.6.2 -> 1.6.3`                                                     |
| [`be407dca`](https://github.com/NixOS/nixpkgs/commit/be407dcae2df617424f02b9872aaec160b0c5906) | `exploitdb: 2022-04-23 -> 2022-04-27`                                            |
| [`5e718d70`](https://github.com/NixOS/nixpkgs/commit/5e718d7071ddf747a09b96e257946345023301fd) | `coqPackages.metalib: clean & init at 8.15`                                      |
| [`d05cb235`](https://github.com/NixOS/nixpkgs/commit/d05cb23570db5eb89d1e8aaa1866089902b32318) | `python310Packages.hg-evolve: 10.5.0 -> 10.5.1`                                  |
| [`22f45cec`](https://github.com/NixOS/nixpkgs/commit/22f45cecb6affc8dbd365df211b015d2e7d55b30) | `python39Packages.pysigma: 0.5.0 -> 0.5.1`                                       |
| [`9cdfc7d6`](https://github.com/NixOS/nixpkgs/commit/9cdfc7d6121711b5a56fc727963261eacb84d7c4) | `chromiumDev: 102.0.5005.12 -> 102.0.5005.22`                                    |
| [`4bd5ee55`](https://github.com/NixOS/nixpkgs/commit/4bd5ee55abfb9c205c923a24cd4c7cf11f6a9edb) | `nodePackages.prisma: 3.12.0 -> 3.13.0`                                          |
| [`253e99ce`](https://github.com/NixOS/nixpkgs/commit/253e99cecc54a561d98978c282aab04c40101d10) | `python39Packages.ismartgate: disable failing tests`                             |
| [`b5c8ac94`](https://github.com/NixOS/nixpkgs/commit/b5c8ac94efb6ee94e8131c17bac1878962502ad6) | `trivy: 0.27.0 -> 0.27.1`                                                        |
| [`f51bc802`](https://github.com/NixOS/nixpkgs/commit/f51bc80264f2ce146cd21d3948e2be1d8a072f53) | `clightning: 0.10.2 -> 0.11.0.1`                                                 |
| [`1a4307af`](https://github.com/NixOS/nixpkgs/commit/1a4307af6dfcdc3b097f03a26feec9181920381d) | `jasmin-compiler: init at 21.0`                                                  |
| [`a6e064c5`](https://github.com/NixOS/nixpkgs/commit/a6e064c5db77116ca300b2d8e92147f4376f0054) | `solaar: 1.1.1 -> 1.1.3`                                                         |
| [`20a72fd1`](https://github.com/NixOS/nixpkgs/commit/20a72fd1ab5af906fb6f74972ea0d9d599414823) | `jc: 1.18.6 -> 1.18.7`                                                           |
| [`7b7c8bab`](https://github.com/NixOS/nixpkgs/commit/7b7c8bab641cefc9c720d5eb0b0e6f948e587b56) | `python39Packages.connexion: 2.12.0 -> 2.13.0`                                   |
| [`d8c63a3f`](https://github.com/NixOS/nixpkgs/commit/d8c63a3fcec2b26a270d14e160866365c4ab9736) | `roon-server: 1.8-923 -> 1.8-933`                                                |
| [`73afb795`](https://github.com/NixOS/nixpkgs/commit/73afb7958bfd157cde4924d9d0f0f313e3071bbc) | `python39Packages.pyiqvia: 2021.11.0 -> 2022.04.0`                               |
| [`209c579d`](https://github.com/NixOS/nixpkgs/commit/209c579d7fc51406f7a06fac39923254dcdc3a9f) | `gucci: 0.1.0 -> 1.5.4`                                                          |
| [`36f4c18c`](https://github.com/NixOS/nixpkgs/commit/36f4c18c2b08c5f2e950afb023eaef58b368ce6d) | `organicmaps: 2022.03.23-4-android -> 2022.04.27-2`                              |
| [`c3af7faa`](https://github.com/NixOS/nixpkgs/commit/c3af7faa264c32bf0845a0f75ea0cbe28ff4061e) | `python310Packages.zha-quirks: disable on older Python releases`                 |
| [`e7f711ef`](https://github.com/NixOS/nixpkgs/commit/e7f711ef70952a39d864d34e27088f68a7b3cfa8) | `python310Packages.pyopenuv: update disable`                                     |
| [`3a8946a7`](https://github.com/NixOS/nixpkgs/commit/3a8946a7ef3a0cbf5baafda24e50e64e7e57b9bd) | `python3Packages.teslajsonpy: update disable`                                    |
| [`dc26602a`](https://github.com/NixOS/nixpkgs/commit/dc26602aedb9831093ff5c25673354751532a4d1) | `nixos-container: Add tests to passthru for CI`                                  |
| [`3c49151f`](https://github.com/NixOS/nixpkgs/commit/3c49151f154a3872eb278c214863d926a4f8abf6) | `nixos/nixos-containers: Add warning on unsupported state version combo`         |
| [`01e35db2`](https://github.com/NixOS/nixpkgs/commit/01e35db27895076fca4be0436ed584393cd0c8b0) | `release-notes: Add release note about nixos containers directory moves`         |
| [`81d192cf`](https://github.com/NixOS/nixpkgs/commit/81d192cfa6d8f5ccbfe797c0006c533945327a03) | `nixos-container: Add compatibility hack for pre-22.05 state/config directories` |
| [`f535d6f4`](https://github.com/NixOS/nixpkgs/commit/f535d6f45ef9556d392de76c2dd1c26b436c4ea8) | `nixos-container: Use new configuration & state directories`                     |
| [`7d9a979b`](https://github.com/NixOS/nixpkgs/commit/7d9a979b2e176190caadc9d73ccc07f36b6efa91) | `nixos-container: Make configuration and state directories configurable`         |
| [`85919894`](https://github.com/NixOS/nixpkgs/commit/85919894405c54467e978a7e580f85f48f939ef7) | `gnome.zenity: 3.42.0 -> 3.42.1`                                                 |
| [`22bb11f3`](https://github.com/NixOS/nixpkgs/commit/22bb11f3016d86bfd0cf6db992343a25559e358b) | `gnome.gnome-software: 42.0 -> 42.1`                                             |
| [`5ad3773d`](https://github.com/NixOS/nixpkgs/commit/5ad3773d7f8eaac650aa1883f29671b517e235f2) | `gnome.gnome-remote-desktop: 42.1 -> 42.1.1`                                     |
| [`4a0b1df9`](https://github.com/NixOS/nixpkgs/commit/4a0b1df9fc1d367de3652857567cfbc056f38de1) | `gnome.gnome-calendar: 42.0 -> 42.1`                                             |
| [`8dd84e8e`](https://github.com/NixOS/nixpkgs/commit/8dd84e8e7125f3644f3b3a82fdeb8c2c795b09dd) | `gnome.ghex: 42.1 -> 42.2`                                                       |
| [`dd2bc2a7`](https://github.com/NixOS/nixpkgs/commit/dd2bc2a721a3c4ba87d10f98425f72c92f5b5033) | `goffice: disable tests on powerpc64le`                                          |
| [`f34d90c5`](https://github.com/NixOS/nixpkgs/commit/f34d90c56d4c011eb7c4f25aa565875de770ce7a) | `starship: 1.6.2 -> 1.6.3`                                                       |
| [`b18f7fb2`](https://github.com/NixOS/nixpkgs/commit/b18f7fb2de40b9915a6d5fb4774f28c305abdd61) | `mkcert: 1.4.3 -> 1.4.4`                                                         |
| [`bcda9dc4`](https://github.com/NixOS/nixpkgs/commit/bcda9dc42f6ac9263b2a91b61dca844e777b716a) | `brakeman: 5.1.1 -> 5.2.2`                                                       |
| [`c1da6fc4`](https://github.com/NixOS/nixpkgs/commit/c1da6fc4ce95fe59f2c0c8e7cee580a37e0bb94b) | `nodejs-16_x: 16.14.2 -> 16.15.0`                                                |
| [`d4cb6b8e`](https://github.com/NixOS/nixpkgs/commit/d4cb6b8e860778d94c7eba912d4535ade5b0b60d) | `python310Packages.trimesh: 3.10.8 -> 3.11.2`                                    |
| [`80d44807`](https://github.com/NixOS/nixpkgs/commit/80d4480778f581d5b73e4464eeb08ae0974e72c2) | `sd-image-aarch64: deduplicate cm4 section`                                      |
| [`1d8e889d`](https://github.com/NixOS/nixpkgs/commit/1d8e889dc073c40fcdf49930dfb30c8d302ef177) | `gitRepo: 2.24 -> 2.24.1`                                                        |
| [`1976ab0a`](https://github.com/NixOS/nixpkgs/commit/1976ab0a528e082512cc5048970b7a9e691fb177) | `dfeet: add teams.gnome.members to maintainers`                                  |
| [`9242f0b5`](https://github.com/NixOS/nixpkgs/commit/9242f0b5cec48028deef599cef561446c99cd6e1) | `evolution-ews: 3.44.0 -> 3.44.1`                                                |
| [`86055bfb`](https://github.com/NixOS/nixpkgs/commit/86055bfb5336322119bc9d40028fc67442db4096) | `python310Packages.teslajsonpy: 2.0.3 -> 2.1.0`                                  |
| [`73c419d3`](https://github.com/NixOS/nixpkgs/commit/73c419d33fa8c1ca058d5338d9d3016beb01adb2) | `amberol: 0.3.0 -> 0.4.3`                                                        |
| [`05942771`](https://github.com/NixOS/nixpkgs/commit/059427718385d23e125ddfbb630eda0d6fbc4178) | `ubootRaspberryPi4_64bit: remove NVMe support patches`                           |
| [`21b28447`](https://github.com/NixOS/nixpkgs/commit/21b28447eb5b32dbca7cfd51acf716bf41eb732c) | `uboot: add node on where rpi-cm4 patches come from`                             |
| [`77bb75d6`](https://github.com/NixOS/nixpkgs/commit/77bb75d6a24e28d2b1f3be54c4194b22b63d054f) | `ubootRaspberryPi4_64bit: rebase patch series`                                   |
| [`cff95d11`](https://github.com/NixOS/nixpkgs/commit/cff95d119343fe2808516a0f8f86c8ba0963b29c) | `ubootRaspberryPi4_64bit: add patch for USB stall with non-MSD USB devices`      |
| [`11c1152e`](https://github.com/NixOS/nixpkgs/commit/11c1152e0f4f35e22249bc8d02e1d30e29b53032) | `sd-image-aarch64: add dtbs for rpi-400 and cm4s`                                |
| [`b30105b7`](https://github.com/NixOS/nixpkgs/commit/b30105b7c28b6510980101e8266b2268b1e2313f) | `ubootRaspberryCM4_64bit: merge with ubootRaspberryPi4_64bit`                    |
| [`aca45f8c`](https://github.com/NixOS/nixpkgs/commit/aca45f8c678deaa35dc407586e91d302d36dc74d) | `raspberrypiWirelessFirmware: fix install`                                       |
| [`02530e21`](https://github.com/NixOS/nixpkgs/commit/02530e21ed21bffad8e22a83f6fb02a77e722618) | `python310Packages.pyopenuv: 2021.11.0 -> 2022.04.0`                             |
| [`d9e593ed`](https://github.com/NixOS/nixpkgs/commit/d9e593ed5889f3906dc72811c45bf684be8865cf) | `git-cliff: 0.6.1 -> 0.7.0`                                                      |
| [`c425aa49`](https://github.com/NixOS/nixpkgs/commit/c425aa4989502c9dcafdd570ad1dbe89a2976587) | `cargo-make: 0.35.10 -> 0.35.11`                                                 |
| [`52c0362b`](https://github.com/NixOS/nixpkgs/commit/52c0362bd143e158725e267c9f9e0c5a9bf61d6d) | `python310Packages.zha-quirks: 0.0.72 -> 0.0.73`                                 |
| [`f089fdbc`](https://github.com/NixOS/nixpkgs/commit/f089fdbc8068878ce430e94df851c83c1d848567) | `Vulkan: 1.2.198.0 -> 1.3.211.0`                                                 |
| [`d2f1613f`](https://github.com/NixOS/nixpkgs/commit/d2f1613f15d68eadfd882a68f2ac42e02d945214) | `python39Packages.pylast: 4.5.0 -> 5.0.0`                                        |
| [`1d4f4d34`](https://github.com/NixOS/nixpkgs/commit/1d4f4d3437191b1d152d5d28e9e29d758c897a39) | `obsidian: 0.13.30 -> 0.14.6`                                                    |
| [`0eb22f6a`](https://github.com/NixOS/nixpkgs/commit/0eb22f6abc3a45926aad1fe0bdb4f7afebfe242e) | `python3Packages.pytest-aiohttp: 1.0.3 -> 1.0.4`                                 |
| [`a356e866`](https://github.com/NixOS/nixpkgs/commit/a356e8667645e4d1d40966a049790f32f2ff84db) | `tpm2-pkcs11: 1.7.0 -> 1.8.0`                                                    |
| [`dc1ac222`](https://github.com/NixOS/nixpkgs/commit/dc1ac22201007d15aebb7b05acf9dde4b2162db4) | `sharedown: 3.1.0 -> 4.0.2`                                                      |
| [`fb18ee26`](https://github.com/NixOS/nixpkgs/commit/fb18ee26ee9c634c6bcc8482c0a9755775a9b4e9) | `xfce.xfce4-terminal: 1.0.1 -> 1.0.2`                                            |
| [`61295628`](https://github.com/NixOS/nixpkgs/commit/61295628015510062c2fcaeb6b782cc9c563a073) | `checkov: 2.0.1084 -> 2.0.1085`                                                  |
| [`e0de711e`](https://github.com/NixOS/nixpkgs/commit/e0de711e368a2899a5737e2b09c94e45e231e981) | `luna-icons: 1.9.1 -> 2.0`                                                       |
| [`9be76f92`](https://github.com/NixOS/nixpkgs/commit/9be76f9284014247a0f7a0542294046e857e3a88) | `python39Packages.pyfritzhome: 0.6.4 -> 0.6.5`                                   |
| [`dcfaae66`](https://github.com/NixOS/nixpkgs/commit/dcfaae66794be7ff958efe6460eee5f8438a7f45) | `nixos/modules/profiles/all-hardware: add nvme to initrd modules`                |
| [`323f123f`](https://github.com/NixOS/nixpkgs/commit/323f123f6afee22cc0c642988a12285ba0f11b3a) | `ubootRaspberryCM4_64bit: add all NVME patches`                                  |
| [`ca0c9279`](https://github.com/NixOS/nixpkgs/commit/ca0c9279ab2471bd8bf67681fb57fe33adbccb27) | `ubootRaspberryCM4_64bit: enable USB and NVME`                                   |
| [`d094a3e1`](https://github.com/NixOS/nixpkgs/commit/d094a3e175fb3e1593adcda6a4e973946785dd13) | `uboot: enable parallel building again`                                          |
| [`f6f41cf7`](https://github.com/NixOS/nixpkgs/commit/f6f41cf740527b804abb8ae30f69a2fb534c35f3) | `uboot: 2021.10 -> 2022.01`                                                      |
| [`faf42ffb`](https://github.com/NixOS/nixpkgs/commit/faf42ffbd07f0c877258c8b519c7e973949f89c7) | `ubootRaspberryCM4_64bit: init`                                                  |
| [`d1fef1e7`](https://github.com/NixOS/nixpkgs/commit/d1fef1e7c370a39b639836726e956574d4092793) | `sd-image-aarch64: add support for the RaspberryPi CM4`                          |
| [`f4f0f8a6`](https://github.com/NixOS/nixpkgs/commit/f4f0f8a62b04aae6af04d0f11e328e9f8acaf737) | `hyperspace-cli: unbreak`                                                        |
| [`b12ff7c9`](https://github.com/NixOS/nixpkgs/commit/b12ff7c9ec3797ba2c44538658fd5df2bf3d88a5) | `python39Packages.policyuniverse: 1.5.0.20220421 -> 1.5.0.20220426`              |
| [`22989073`](https://github.com/NixOS/nixpkgs/commit/229890736b74c3ba26eebfbcc6620ae31b5b9bf9) | `python39Packages.peewee: 3.14.9 -> 3.14.10`                                     |
| [`879830d8`](https://github.com/NixOS/nixpkgs/commit/879830d817c67edf5879e318cb49d23c620476ce) | `chromium: 100.0.4896.127 -> 101.0.4951.41`                                      |
| [`97635ecf`](https://github.com/NixOS/nixpkgs/commit/97635ecf20ceef281d3364d151780030f5014244) | `python39Packages.denonavr: 0.10.10 -> 0.10.11`                                  |
| [`b44556ea`](https://github.com/NixOS/nixpkgs/commit/b44556ea92b9ccaf42d322bb9e1f90d6e514aed5) | `python39Packages.beautifulsoup4: 4.10.0 -> 4.11.1`                              |
| [`2f81cbdc`](https://github.com/NixOS/nixpkgs/commit/2f81cbdc903a45e3e53c23f58971813dbdd5f7c7) | `python39Packages.amqp: 5.1.0 -> 5.1.1`                                          |
| [`39cb2d6e`](https://github.com/NixOS/nixpkgs/commit/39cb2d6e3f7935cc8fe4b2115a8a0439e71771b0) | `python39Packages.aiomysql: 0.0.21 -> 0.1.0`                                     |
| [`2975ad11`](https://github.com/NixOS/nixpkgs/commit/2975ad119528863d4bdb28bc160c9072e39b1c02) | `duply: 2.3.1 -> 2.4`                                                            |
| [`8c736783`](https://github.com/NixOS/nixpkgs/commit/8c736783979cbbbaa54b1e5b829355940445acd1) | `python39Packages.aiohttp-apispec: 3.0.0b1 -> 3.0.0b2`                           |