### PR TITLE
chore(flake/nixpkgs): `6766fb65` -> `49a2bcc6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1651114127,
-        "narHash": "sha256-/lLC0wkMZkAdA5e1W76SnJzbhfOGDvync3VRHJMtAKk=",
+        "lastModified": 1654012153,
+        "narHash": "sha256-In+gfoH2Tnf/UmpzeuGlfuexU2EC4QIelBsm2zMK5AE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6766fb6503ae1ebebc2a9704c162b2aef351f921",
+        "rev": "49a2bcc6e2065909c701f862f9a1a62b3082b40a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
| [`87d4a066`](https://github.com/NixOS/nixpkgs/commit/87d4a0667bfb19b320e3c2b7250a678a688a9aee) | `python310Packages.blocksat-cli: 0.4.3 -> 0.4.4`                                                                               |
| [`ab1dd069`](https://github.com/NixOS/nixpkgs/commit/ab1dd069c74d984992fa03cb94da97709a153518) | `firefox-devedition-bin-unwrapped: 101.0b9 -> 102.0b1`                                                                         |
| [`172e3144`](https://github.com/NixOS/nixpkgs/commit/172e3144ab96d656eb6570b63683570f4424b624) | `firefox-beta-bin-unwrapped: 101.0b9 -> 102.0b1`                                                                               |
| [`78ffb8f7`](https://github.com/NixOS/nixpkgs/commit/78ffb8f7aed3aeafd3ebe6b081f96fcc097314e7) | `spidermonkey_91: 91.9.1 -> 91.10.0`                                                                                           |
| [`f89d5a7f`](https://github.com/NixOS/nixpkgs/commit/f89d5a7f2cbcd4e1c54394bd5071349cbdb71113) | `firefox-esr-91-unwrapped: 91.9.1esr -> 91.10.0esr`                                                                            |
| [`8353459d`](https://github.com/NixOS/nixpkgs/commit/8353459d921258e32b62a90506ba8b7f99e7949c) | `firefox-bin-unwrapped: 100.0.2- -> 101.0`                                                                                     |
| [`33271183`](https://github.com/NixOS/nixpkgs/commit/332711833d9db8063d331590b0bb69dbb55643e2) | `firefox-unwrapped: 100.0.2- -> 101.0`                                                                                         |
| [`5643714d`](https://github.com/NixOS/nixpkgs/commit/5643714dea562f0161529ab23058562afeff46d0) | `stdenvBootstrapTools: inherit {cross,local}System`                                                                            |
| [`f51cb36f`](https://github.com/NixOS/nixpkgs/commit/f51cb36f2c98a991b8e4fbe257dc146577075f84) | `replay-io: init at 20220516-372662e7c79d-a9c63f38ea9b, replay-node-cli: init at 20220506-096c12cb47eb-a1d05f422dff (#166813)` |
| [`36049542`](https://github.com/NixOS/nixpkgs/commit/36049542b81b97c1d93131cd986856967719f365) | `gnome.gnome-boxes: 42.0.1 -> 42.1`                                                                                            |
| [`a9ce8f1e`](https://github.com/NixOS/nixpkgs/commit/a9ce8f1ef222c4b03773e5931176189cb59daa8b) | `ocamlPackages.json-data-encoding: 0.10 -> 0.11`                                                                               |
| [`d27cc392`](https://github.com/NixOS/nixpkgs/commit/d27cc392f04381074e5c71a2d5356442b1610cac) | `ocamlPackages.resto:  0.6.1 -> 0.7`                                                                                           |
| [`c356e724`](https://github.com/NixOS/nixpkgs/commit/c356e7246f8b1a65b8edbe1c57e9f895caabeab5) | `gtk4: 4.6.4 -> 4.6.5`                                                                                                         |
| [`2c746066`](https://github.com/NixOS/nixpkgs/commit/2c746066649266eec0ce529f2091e09e905ece94) | `.github/PULL_REQUEST_TEMPLATE.md: 21.11 -> 22.05`                                                                             |
| [`5db40e76`](https://github.com/NixOS/nixpkgs/commit/5db40e768d1447624235b27d7176726550eb353f) | `dpdk-kmods.src: use HTTPS URL`                                                                                                |
| [`b654502b`](https://github.com/NixOS/nixpkgs/commit/b654502b2bb0026cdfd4d9cecdd5656745866c84) | `terraform-providers: also include name in error messages`                                                                     |
| [`97bdb3c6`](https://github.com/NixOS/nixpkgs/commit/97bdb3c6450c58d16eeb93f4cf24500ddbe2f75c) | `nearcore: 1.26.0 -> 1.26.1`                                                                                                   |
| [`83505670`](https://github.com/NixOS/nixpkgs/commit/835056702eb6e1fdf36f34e3cb4acf9e53ea17cd) | `python310Packages.regenmaschine: 2022.05.0 -> 2022.05.1`                                                                      |
| [`376897ce`](https://github.com/NixOS/nixpkgs/commit/376897ced34becbfce58950225360c28e0a3ecf0) | `astral: init at 5.7.1`                                                                                                        |
| [`32e26d26`](https://github.com/NixOS/nixpkgs/commit/32e26d2627154a54f42334dc31bf5338dc7a97ff) | `release-notes: fix typo`                                                                                                      |
| [`cfaec958`](https://github.com/NixOS/nixpkgs/commit/cfaec958cc81014eae1b8f35827c7c46b4c74207) | `README: 21.11 -> 22.05`                                                                                                       |
| [`e70ebbd0`](https://github.com/NixOS/nixpkgs/commit/e70ebbd0bfa1e9245d70b7ab80739e53ecdcc233) | `gnome.gnome-software: 42.1 -> 42.2`                                                                                           |
| [`6abc75c9`](https://github.com/NixOS/nixpkgs/commit/6abc75c9400201c7b9eb14680d1eaf634f961434) | `python310Packages.pex: 2.1.90 -> 2.1.91`                                                                                      |
| [`7064d75b`](https://github.com/NixOS/nixpkgs/commit/7064d75b711a866e159b46bcd17d97d2f557b118) | `python310Packages.hahomematic: 1.6.1 -> 1.6.2`                                                                                |
| [`aaf94758`](https://github.com/NixOS/nixpkgs/commit/aaf94758f3634888312b0ec5e3dd7bbd59543a88) | `python310Packages.hatasmota: 0.5.0 -> 0.5.1`                                                                                  |
| [`d10af529`](https://github.com/NixOS/nixpkgs/commit/d10af5290b676a957e2c34098e77636cf14b90a1) | `cfripper: 1.10.0 -> 1.11.0`                                                                                                   |
| [`cea2a516`](https://github.com/NixOS/nixpkgs/commit/cea2a516382e9ca7f9b0b31618fd14db9d773302) | `python310Packages.pyhiveapi: 0.5.3 -> 0.5.4`                                                                                  |
| [`2cae94e5`](https://github.com/NixOS/nixpkgs/commit/2cae94e56a24599777e70e4d878acf9c52c2a834) | `ncdc: 1.22.1 -> 1.23`                                                                                                         |
| [`67dffc30`](https://github.com/NixOS/nixpkgs/commit/67dffc3000fb931058e39a2967a4d66d3cc05af4) | `python3Packages.celery: unmark as broken`                                                                                     |
| [`71c7efa3`](https://github.com/NixOS/nixpkgs/commit/71c7efa3877218ea3cd6ed07f95e804dd10d7daf) | `python3Packages.celery: skip hydra-failing tests on darwin`                                                                   |
| [`b787f238`](https://github.com/NixOS/nixpkgs/commit/b787f238f4d091a083cb3600db81f763fa27c8c5) | `python310Packages.webtest-aiohttp: remove superflouses inputs`                                                                |
| [`07517967`](https://github.com/NixOS/nixpkgs/commit/07517967de14d16de525f0fa11a2962fb2557466) | `python310Packages.verboselogs: switch to pytestCheckHook`                                                                     |
| [`113003f1`](https://github.com/NixOS/nixpkgs/commit/113003f1a279840ca055ecb84bd5a6a642f9483c) | `python310Packages.huum: init at 0.5.0`                                                                                        |
| [`e9ad7e5f`](https://github.com/NixOS/nixpkgs/commit/e9ad7e5feca8a185cb28363b9e33d9fbe7ba6624) | `python310Packages.huggingface-hub: disable on older Python releases`                                                          |
| [`d8219583`](https://github.com/NixOS/nixpkgs/commit/d821958373bddedc25d8100abcbf4118580fa5a9) | `python310Packages.nettigo-air-monitor: remove postPatch`                                                                      |
| [`4c885335`](https://github.com/NixOS/nixpkgs/commit/4c8853358de627904f31d98db6f2dfb5db4e789c) | `python310Packages.nettigo-air-monitor: 1.2.4 -> 1.3.0`                                                                        |
| [`ab76f322`](https://github.com/NixOS/nixpkgs/commit/ab76f3220da5b6cfdf39f16683ec4be53299fc79) | `xedit: fix build on darwin`                                                                                                   |
| [`66ff8747`](https://github.com/NixOS/nixpkgs/commit/66ff8747b81d2f024c7a36d55859c004c4095616) | `python310Packages.pysnmplib: 5.0.15 -> 5.0.16`                                                                                |
| [`951488b1`](https://github.com/NixOS/nixpkgs/commit/951488b16707a23f0e2a8573337277ee7b7fc876) | `ansible-lint: 6.2.1 -> 6.2.2`                                                                                                 |
| [`c9098ff0`](https://github.com/NixOS/nixpkgs/commit/c9098ff0bb3f08ada15b0b2a47095a34488e0ef0) | `python310Packages.pyramid_jinja2: disable failing tests`                                                                      |
| [`6f7557f8`](https://github.com/NixOS/nixpkgs/commit/6f7557f8c6f2727a0398786c1100a9c232bf2f5d) | `python3Packages.uamqp: use openssl on darwin-aarch64`                                                                         |
| [`01202165`](https://github.com/NixOS/nixpkgs/commit/012021659f68cfdb982b54e463eb456fc8767926) | `libnatspec: unmark broken on darwin`                                                                                          |
| [`8e113240`](https://github.com/NixOS/nixpkgs/commit/8e113240bbf7e5b630cde79b0fe27f8ed97131e7) | `libnatspec: fix build on darwin`                                                                                              |
| [`62089e3e`](https://github.com/NixOS/nixpkgs/commit/62089e3ecaa332367dbb0e077533df83ffee719e) | `checkov: 2.0.1174 -> 2.0.1175`                                                                                                |
| [`51b506f8`](https://github.com/NixOS/nixpkgs/commit/51b506f8de4bdd2122bd2b6e7166245a2e72f0da) | `python3.pkgs.pyfuse3: fix broken mark`                                                                                        |
| [`18d53f80`](https://github.com/NixOS/nixpkgs/commit/18d53f807ea456d19609ef4e14a48738d8945d75) | `docker-compose_2: 2.5.1 -> 2.6.0`                                                                                             |
| [`7c495114`](https://github.com/NixOS/nixpkgs/commit/7c495114745a1bd9eaa9d2af67c2d76c6e105fa8) | `python310Packages.authheaders: remove backport ipaddress (#175415)`                                                           |
| [`63cbdf67`](https://github.com/NixOS/nixpkgs/commit/63cbdf67ae20521d26e34aae181bc1eea3ec8588) | `fix font fallout from extraPostFetch -> postFetch (#175381)`                                                                  |
| [`e47fff26`](https://github.com/NixOS/nixpkgs/commit/e47fff26cc89000efc72fb66aabda84b75218657) | `deltachat-desktop: 1.28.2 -> 1.30.0`                                                                                          |
| [`09118d3d`](https://github.com/NixOS/nixpkgs/commit/09118d3debc74c8b8a2b262ae72900c2f3ca7214) | `python310Packages.ua-parser: remove unused pyyaml, add pythonImportsCheck`                                                    |
| [`bec4b99b`](https://github.com/NixOS/nixpkgs/commit/bec4b99baad961400eb64a00a78211debe1e091a) | `python310Packages.huggingface-hub: 0.6.0 -> 0.7.0`                                                                            |
| [`cbaacfb8`](https://github.com/NixOS/nixpkgs/commit/cbaacfb8dfa2ddadfb152fa8ef163b40db9041af) | `Release 22.05`                                                                                                                |
| [`1980cec0`](https://github.com/NixOS/nixpkgs/commit/1980cec089c745cd3c67b7f0772b2c3feb2c9e42) | `python310Packages.pyramid_chameleon: fix compatibility with pyramid 2`                                                        |
| [`bab6e292`](https://github.com/NixOS/nixpkgs/commit/bab6e2925668d59aada968fec93930d26dbbfec0) | `scala-cli: 0.1.5 -> 0.1.6`                                                                                                    |
| [`567b83eb`](https://github.com/NixOS/nixpkgs/commit/567b83ebbd9961717a83233970209918b6430867) | `scala-cli: add updater`                                                                                                       |
| [`643be073`](https://github.com/NixOS/nixpkgs/commit/643be073a36dc71d3e45af0960b8f5c24c9c76dc) | `python3Packages.fpylll: 0.5.6 -> 0.5.7`                                                                                       |
| [`80d6f179`](https://github.com/NixOS/nixpkgs/commit/80d6f179b9672dea9b0ac05444a26dbfffdf3c55) | `procs: unbreak on aarch64-darwin`                                                                                             |
| [`963e1c79`](https://github.com/NixOS/nixpkgs/commit/963e1c79dcd3ada2ecb302edc6ea15634531881b) | `nixVersions.unstable: pre20220512 -> pre20220530`                                                                             |
| [`15ba69d1`](https://github.com/NixOS/nixpkgs/commit/15ba69d1b7966100083f80743a571f3b7c3f20d7) | `python310Packages.elementpath: 2.5.2 -> 2.5.3`                                                                                |
| [`b67d16e7`](https://github.com/NixOS/nixpkgs/commit/b67d16e7adec9649dfc2418322eeaad5951afd71) | `i3-rounded: init at 4.20.1 (#174215)`                                                                                         |
| [`9253fc4a`](https://github.com/NixOS/nixpkgs/commit/9253fc4a56a6c3c0eef4de0664fc3abb4223557e) | `btcpayserver: 1.5.3 -> 1.5.4`                                                                                                 |
| [`342f0879`](https://github.com/NixOS/nixpkgs/commit/342f0879ca53094ed56fc6a03c20fe000dba4f96) | `n8n: 0.177.0 → 0.179.0`                                                                                                       |
| [`b5c01026`](https://github.com/NixOS/nixpkgs/commit/b5c0102678e1e23275b9149bed4ecd70a0f13d35) | `python310Packages.caldav: 0.9.0 -> 0.9.1`                                                                                     |
| [`7a54d237`](https://github.com/NixOS/nixpkgs/commit/7a54d237e0c459faa7d9f328c7e99c6efb9bff41) | `snakemake: 7.7.0 -> 7.8.0 (#174592)`                                                                                          |
| [`4bd0fe1e`](https://github.com/NixOS/nixpkgs/commit/4bd0fe1e310c28b13672d75c26ce3a6735dd3bc8) | `cloudflared: 2022.5.1 -> 2022.5.2`                                                                                            |
| [`d29cd82b`](https://github.com/NixOS/nixpkgs/commit/d29cd82bfb406e700b655bc4fafd661d2aa039f9) | `elmPackages.elm-pages: init at 2.1.11`                                                                                        |
| [`631fb48f`](https://github.com/NixOS/nixpkgs/commit/631fb48f815488d1d5bda411364799ed3c5e10c5) | `add jali-clarke to maintainers list`                                                                                          |
| [`0e287081`](https://github.com/NixOS/nixpkgs/commit/0e287081aba179a61eed086836cb05d1b71e26ac) | `python310Packages.robotframework: 5.0 -> 5.0.1`                                                                               |
| [`cd0956e5`](https://github.com/NixOS/nixpkgs/commit/cd0956e5d80ea83f9b92745bfa14d4c5a5cdde98) | `libportal/libqalculate: Unbreak`                                                                                              |
| [`06f08e97`](https://github.com/NixOS/nixpkgs/commit/06f08e974977cf2a5a5ce17e5ac9bb7e44ef23bb) | `automoc4: remove`                                                                                                             |
| [`437c8e65`](https://github.com/NixOS/nixpkgs/commit/437c8e6554911095f0557d524e9d2ffe1c26e33a) | `bullet: 3.23 -> 3.24`                                                                                                         |
| [`ac0907f3`](https://github.com/NixOS/nixpkgs/commit/ac0907f326256b29d4d06d2d749d353b945294f4) | `release-alternatives.nix: fix eval`                                                                                           |
| [`369710ef`](https://github.com/NixOS/nixpkgs/commit/369710eff7adc37189c2f55300ee1ffde1bf797d) | `python310Packages.azure-mgmt-datafactory: 2.5.0 -> 2.6.0`                                                                     |
| [`908245b5`](https://github.com/NixOS/nixpkgs/commit/908245b5532e4fcfedc8e6f15abc330ad5942506) | `v2ray: 4.44.0 -> 4.45.0`                                                                                                      |
| [`90ce1f86`](https://github.com/NixOS/nixpkgs/commit/90ce1f86b9bec2f468fd82316d12b1f9d24397d7) | `cri-tools: 1.24.1 -> 1.24.2`                                                                                                  |
| [`26243136`](https://github.com/NixOS/nixpkgs/commit/26243136fe7559eb139d0bc6bda5d8a1ad737a3a) | `robomachine: mark broken`                                                                                                     |
| [`afbb0f6f`](https://github.com/NixOS/nixpkgs/commit/afbb0f6ff4a6df918d1f0dc37dd2d4b97cf2881e) | `treewide: pkgs/development/python-modules: mark broken for aarch64-linux`                                                     |
| [`7da0ca2e`](https://github.com/NixOS/nixpkgs/commit/7da0ca2e252799366176081186935682e8b3603a) | `mps: mark broken`                                                                                                             |
| [`cd19a0e7`](https://github.com/NixOS/nixpkgs/commit/cd19a0e7b415de52e67b248fecf1ca566f16fa10) | `swift: mark broken`                                                                                                           |
| [`11ee22d7`](https://github.com/NixOS/nixpkgs/commit/11ee22d797016be02743a9973fe09e0362bcb91b) | `treewide: pkgs/development: mark broken for aarch64-linux`                                                                    |
| [`43370114`](https://github.com/NixOS/nixpkgs/commit/433701147a8a4766edd51114d186a54e19fc13cc) | `treewide: pkgs/applications: mark broken for aarch64-linux`                                                                   |
| [`010f6ee3`](https://github.com/NixOS/nixpkgs/commit/010f6ee30de634c51d0c7337762dee61cb8427ea) | `treewide: mark broken for darwin`                                                                                             |
| [`82ccbc08`](https://github.com/NixOS/nixpkgs/commit/82ccbc08de7bc6fce46b633eb1db1fd6890a3d91) | `luaPackages.luxio: mark broken for darwin`                                                                                    |
| [`7a685488`](https://github.com/NixOS/nixpkgs/commit/7a685488229770b53fffaf81e1aec561a9476130) | `treewide: pkgs/desktops: mark broken for darwin`                                                                              |
| [`033d5579`](https://github.com/NixOS/nixpkgs/commit/033d5579c2e965a35b4d7b41249d809c844906d2) | `treewide: pkgs/servers/sql: mark 2 psql extension broken`                                                                     |
| [`879d2782`](https://github.com/NixOS/nixpkgs/commit/879d278253424b2e63f8b1b7269a244d4e14aa9f) | `treewide: pkgs/servers: mark broken for darwin`                                                                               |
| [`a0dd8198`](https://github.com/NixOS/nixpkgs/commit/a0dd8198cd898a00f036e37b89be1843ab3a1943) | `speedcrunch: mark broken on darwin`                                                                                           |
| [`c312ae98`](https://github.com/NixOS/nixpkgs/commit/c312ae98a15aef70ba7eedbbd66c31fb8d705759) | `tippecanoe: mark broken on darwin as well`                                                                                    |
| [`117ee3af`](https://github.com/NixOS/nixpkgs/commit/117ee3af2ac60518c7ecb80e08b0a058542f598b) | `blender: mark broken on all darwins`                                                                                          |
| [`da846421`](https://github.com/NixOS/nixpkgs/commit/da846421fc1ee9257871f65998358e23b923113d) | `libresprite: mark broken on darwin`                                                                                           |
| [`edde4da4`](https://github.com/NixOS/nixpkgs/commit/edde4da42e7e00fd07dc84d7d6cc34d26ebbb1fd) | `pqrs: mark broken`                                                                                                            |
| [`03bc5717`](https://github.com/NixOS/nixpkgs/commit/03bc5717445bbccda21d10eeecb6ded4c12d08fe) | `treewide: pkgs/development: mark broken for darwin`                                                                           |
| [`c3d7a0ef`](https://github.com/NixOS/nixpkgs/commit/c3d7a0ef4ffbfd2045228e0643a1d03e81b14c4f) | `gnome.gnome-shell-extensions: 42.1 -> 42.2`                                                                                   |
| [`7d58a302`](https://github.com/NixOS/nixpkgs/commit/7d58a30286490b7cf7486093d615195fc7695520) | `treewide: pkgs/development/libraries: mark broken for darwin`                                                                 |
| [`65db3b17`](https://github.com/NixOS/nixpkgs/commit/65db3b17a8a4ba70c371767e7c484f70203080f2) | `treewide: pkgs/development/python-modules: mark broken for darwin`                                                            |
| [`13e0d337`](https://github.com/NixOS/nixpkgs/commit/13e0d337037b3f59eccbbdf3bc1fe7b1e55c93fd) | `treewide: pkgs/development/tools: mark broken for darwin`                                                                     |
| [`0b45cae8`](https://github.com/NixOS/nixpkgs/commit/0b45cae8a35412e461c13c5037dcdc99c06b7451) | `treewide: pkgs/development/compilers: mark broken for darwin`                                                                 |
| [`bd78e1ac`](https://github.com/NixOS/nixpkgs/commit/bd78e1ac1efd7a68b969dc308ce22381bf7a9135) | `sway-launcher-desktop: 1.5.4 -> 1.6.0`                                                                                        |
| [`3ece45bc`](https://github.com/NixOS/nixpkgs/commit/3ece45bc72edf425232867c377a52e3c59bd1bb0) | `gnome.gnome-remote-desktop: 42.1.1 -> 42.2`                                                                                   |
| [`cd21d432`](https://github.com/NixOS/nixpkgs/commit/cd21d43206f6fe58cdee3366a3cf171e69782976) | `gnome.gnome-shell: 42.1 -> 42.2`                                                                                              |
| [`d1b430ec`](https://github.com/NixOS/nixpkgs/commit/d1b430ec3fb1f244566cbdcb55b7515704528321) | `gnome.mutter: 42.1 -> 42.2`                                                                                                   |
| [`daef7d85`](https://github.com/NixOS/nixpkgs/commit/daef7d854ff6b19c5cd7cd03df2169e4881bdd01) | `ansible-later: add to all packages`                                                                                           |
| [`b1aa4a7f`](https://github.com/NixOS/nixpkgs/commit/b1aa4a7f2564156aaa256514f3498758bcbab7da) | `Fix typo in compareLists docstring`                                                                                           |
| [`30186896`](https://github.com/NixOS/nixpkgs/commit/30186896ee517990e51c5256b589c0224c971670) | `nixos/nginx: fix SystemCallFilter for openresty`                                                                              |
| [`c26e3354`](https://github.com/NixOS/nixpkgs/commit/c26e3354a7e8f5233f2a8d3755edbe4262193dae) | `nginxQuic: update`                                                                                                            |
| [`b4849523`](https://github.com/NixOS/nixpkgs/commit/b4849523302484e7cd365a2765f2e8894ace39fe) | `nginx(Stable|Mainline|Quic): use pcre2`                                                                                       |
| [`893214cd`](https://github.com/NixOS/nixpkgs/commit/893214cd0e6d15a2dbadfa5cc680e7ba18e4d1c0) | `nginxMainline: 1.21.6 -> 1.22.0`                                                                                              |
| [`14ef375c`](https://github.com/NixOS/nixpkgs/commit/14ef375cf036a7f8e3ed610f21ed5a591371d747) | `nginxStable: 1.20.2 -> 1.22.0`                                                                                                |
| [`5157246a`](https://github.com/NixOS/nixpkgs/commit/5157246aa4fdcbef7796ef9914c3a7e630c838ef) | `nixos/vmware-guest: Remove the video driver`                                                                                  |
| [`1a20dbc0`](https://github.com/NixOS/nixpkgs/commit/1a20dbc0861e4378975960b7ccfe3d49218965eb) | `bpftrace: Rename *.8 to *.bt.8 to avoid bcc conflicts`                                                                        |
| [`e0115c36`](https://github.com/NixOS/nixpkgs/commit/e0115c36ece8889fbd97c31113c19de07869af62) | `hydra_unstable: passthru pinned nix`                                                                                          |
| [`bb8a7949`](https://github.com/NixOS/nixpkgs/commit/bb8a794957c5646a61cad5d401e7903b69b4c773) | `tile38: 1.27.1 → 1.28.0`                                                                                                      |
| [`138a9422`](https://github.com/NixOS/nixpkgs/commit/138a94228d1019889b437ff7d30c9450078468f8) | `paperless-ngx: add maintainers`                                                                                               |
| [`567e6513`](https://github.com/NixOS/nixpkgs/commit/567e65136f35ec6a2028c677282267e80d7636ec) | `paperless-ngx: 1.6.0 -> 1.7.1`                                                                                                |
| [`ae0df5d3`](https://github.com/NixOS/nixpkgs/commit/ae0df5d38afdb0be90973ddd42b1c9b1059464fd) | `lib.sourceTypes: simplify implementation`                                                                                     |
| [`5bb9bf47`](https://github.com/NixOS/nixpkgs/commit/5bb9bf47740bb98bf6c2c404a086d7ed6a5c595d) | `meta.sourceProvenance: inline hasSourceProvenance`                                                                            |
| [`7906ea6d`](https://github.com/NixOS/nixpkgs/commit/7906ea6d9d938c7f4221c305cfbcc9f8ba63804a) | `allowNonSourcePredicate: use example of categorical permissivity`                                                             |
| [`095eb915`](https://github.com/NixOS/nixpkgs/commit/095eb9153381d240e2ba3e05716b3ce7fda85080) | `meta.sourceProvenance: disallow string values`                                                                                |
| [`81bc106e`](https://github.com/NixOS/nixpkgs/commit/81bc106e080e56e2c85466ea7d4ecf38bc99149c) | `meta.sourceProvenance documentation: clarify it is unaffected by changes to meta.license`                                     |
| [`9d078482`](https://github.com/NixOS/nixpkgs/commit/9d0784829a1dabe24b186c976502a6642f99997c) | `add initial meta.sourceProvenance documentation`                                                                              |
| [`da9162f6`](https://github.com/NixOS/nixpkgs/commit/da9162f667e5833b885edae3631299c0e7005d2b) | `add mechanism for handling meta.sourceProvenance attributes`                                                                  |
| [`0ec13035`](https://github.com/NixOS/nixpkgs/commit/0ec13035f6f28b5ce089cb5a682750cab6a7dd9f) | `python310Packages.pynisher: add pythonImportsCheck`                                                                           |
| [`4b3a039b`](https://github.com/NixOS/nixpkgs/commit/4b3a039b60dc3626b201fa39d1955e1feb08a9b2) | `gh-cal: fix pkg-config`                                                                                                       |
| [`1c6360e3`](https://github.com/NixOS/nixpkgs/commit/1c6360e3330165b0223af760014141c4769acfba) | `python310Packages.whodap: disable on older Python releases`                                                                   |
| [`90a74154`](https://github.com/NixOS/nixpkgs/commit/90a741547ea72c14f7eb26f1e72604b7c3a66e21) | `geomyidae: init at 0.50.1`                                                                                                    |
| [`f6facfe5`](https://github.com/NixOS/nixpkgs/commit/f6facfe59d1e6f891d456a93ac34ae60d7ab2813) | `python310Packages.pims: 0.6.0 -> 0.6.1`                                                                                       |
| [`c78821e0`](https://github.com/NixOS/nixpkgs/commit/c78821e0fd85bfda2622cfd9a187358ea03a09e5) | `python310Packages.wordcloud: switch to pytestCheckHook`                                                                       |
| [`c68d9334`](https://github.com/NixOS/nixpkgs/commit/c68d9334815057d61e379a0adc9019e594867d84) | `python310Packages.flask-httpauth: 4.6.0 -> 4.7.0`                                                                             |
| [`4dc5ea52`](https://github.com/NixOS/nixpkgs/commit/4dc5ea5202a17db17953551a88966cc3e85256c4) | `python310Packages.sphinxcontrib-spelling: 7.4.0 -> 7.4.1`                                                                     |
| [`30d5e606`](https://github.com/NixOS/nixpkgs/commit/30d5e6068af96b31ca729d83f52c238f4082be1a) | `python310Packages.elasticsearch-dsl: remove ipaddress dependency`                                                             |
| [`049be08d`](https://github.com/NixOS/nixpkgs/commit/049be08db3addfd5bdf7361e057b7198b0327e33) | `terraform-providers: update 2022-05-30`                                                                                       |
| [`8bb4fac4`](https://github.com/NixOS/nixpkgs/commit/8bb4fac4053aa311b836c1243f817f5cd506e01d) | `terraform-providers: update scripts`                                                                                          |
| [`5523be73`](https://github.com/NixOS/nixpkgs/commit/5523be73f4913ff62e54a859b4e2359e57229b51) | `python310Packages.brother: 1.2.2 -> 1.2.3`                                                                                    |
| [`cbe5dca3`](https://github.com/NixOS/nixpkgs/commit/cbe5dca334ec05e593d9018df3a087ffaa0ac03a) | `libreddit: 0.22.7 -> 0.22.9`                                                                                                  |
| [`d02116e3`](https://github.com/NixOS/nixpkgs/commit/d02116e31944b63058b592b1025fe090eea6c95f) | `python3Packages.transformers: fix pytorch reference`                                                                          |
| [`412ec27c`](https://github.com/NixOS/nixpkgs/commit/412ec27c1688e282b18453e7ae15a8628a740aa9) | `python310Packages.pysaml2: add missing dependency on setuptools`                                                              |
| [`095219c3`](https://github.com/NixOS/nixpkgs/commit/095219c30c6ab46b496b9abdc218b24b3a35804a) | `natscli: 0.0.32 -> 0.0.33`                                                                                                    |
| [`b32b506a`](https://github.com/NixOS/nixpkgs/commit/b32b506ad0b4a99a7675fb8dea3af209d052875a) | `python310Packages.gpsoauth: cleanup dependencies`                                                                             |
| [`39b60ae0`](https://github.com/NixOS/nixpkgs/commit/39b60ae0b8474ecfaa87d52c36b392b04bb03191) | `python310Packages.pglast: 3.10 -> 3.11`                                                                                       |
| [`c4c4babb`](https://github.com/NixOS/nixpkgs/commit/c4c4babb5533a8e4a5a4c1543d59cf9380e08fd0) | `python310Packages.mail-parser: remove unused input`                                                                           |
| [`7997ad6d`](https://github.com/NixOS/nixpkgs/commit/7997ad6d34032282d83e94a5ece19c2d621fff80) | `python310Packages.fake_factory: drop`                                                                                         |
| [`b885589e`](https://github.com/NixOS/nixpkgs/commit/b885589e7d5934a430ebfe8a4361d3c5e5459682) | `python310Packages.kubernetes: 20.13.0 -> 23.6.0`                                                                              |
| [`eee2bff9`](https://github.com/NixOS/nixpkgs/commit/eee2bff922477148607cb5861dee8ebae0ae778e) | `python310Packages.structlog: remove unused depedency, little cleanup`                                                         |