### PR TITLE
chore(flake/poetry2nix): `3b01c3e3` -> `abc47c71`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1653561148,
-        "narHash": "sha256-JzAttqACdvMOTwkzkJ0jFF8MWIo8Uau4w/XUMyqpnd8=",
+        "lastModified": 1656405165,
+        "narHash": "sha256-p2c9QAnKsiUu0a3iHAkpHkO9jAkMWCbG1HCU7/TrYc0=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "3b01c3e3dc57d511848d8433153ab67db79640e1",
+        "rev": "abc47c71a4920e654e7b2e4261e3e6399bbe2be6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                    | Commit Message                                                                   |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`a6480f2c`](https://github.com/nix-community/poetry2nix/commit/a6480f2ce6d776b27d3be4d98b663e13af5017ca) | `fix: also ignore typing-extensions when resolving dependencies`                 |
| [`f0ef50e3`](https://github.com/nix-community/poetry2nix/commit/f0ef50e3de77a6135c7ad6466b5b78369ca71a03) | `build-systems: add hatchling explicitly for jsonschema >= 4.6.0`                |
| [`f5e8c071`](https://github.com/nix-community/poetry2nix/commit/f5e8c0713c3ab68886577107cc8c5fc5a5b4fcf8) | `build-systems: use hatch-vcs for jsonschema >= 4.6.0`                           |
| [`66276ac7`](https://github.com/nix-community/poetry2nix/commit/66276ac7b6117a24092f5d3c7cc5734177c63ae0) | `build-systems: switch traitlets to hatchling`                                   |
| [`2ab471d2`](https://github.com/nix-community/poetry2nix/commit/2ab471d272c5a255cd5585b85735fca6ae77513c) | `Refactor build system object logic`                                             |
| [`a4276677`](https://github.com/nix-community/poetry2nix/commit/a4276677cd30891d01b91c797e23f19afc05d6a0) | `Use poetry-core build system for linz-logger`                                   |
| [`128a87bb`](https://github.com/nix-community/poetry2nix/commit/128a87bbfb4ab21895f479ac0570ec00ec581194) | `Use hatchling build system for wcmatch`                                         |
| [`684abcc3`](https://github.com/nix-community/poetry2nix/commit/684abcc3792e65ac540fb113c243a67625230014) | `Use hatchling build system for bracex`                                          |
| [`76d40119`](https://github.com/nix-community/poetry2nix/commit/76d4011945e964e12824a865ed9c8cd099d54424) | `Allow lone "until" keys in build-system.json attrs`                             |
| [`c7a61ce9`](https://github.com/nix-community/poetry2nix/commit/c7a61ce945a1fa2b174d7462880c3f9c03939eb0) | `Add experimental extension to build-systems.json`                               |
| [`64c2b6c3`](https://github.com/nix-community/poetry2nix/commit/64c2b6c381424ee0b8ae78044d0525c024509d63) | `build-systems: add jsonschema`                                                  |
| [`debb8aa9`](https://github.com/nix-community/poetry2nix/commit/debb8aa941b7650992296a6d7c3fd10f1a3669e1) | `build-systems: sane-python`                                                     |
| [`bf761f97`](https://github.com/nix-community/poetry2nix/commit/bf761f9726c36f574f0760e7a0d8275b20e51f12) | `overrides.lightgbm: add temporary home directory for source build`              |
| [`e4fb785f`](https://github.com/nix-community/poetry2nix/commit/e4fb785f59d00b3e8638c9b4bc9c094317216f94) | `orjson 3.7.2`                                                                   |
| [`0ba24302`](https://github.com/nix-community/poetry2nix/commit/0ba24302c1fc544e0525348599a43186ad724a56) | `overrides.lightgbm: add cmake`                                                  |
| [`b924859a`](https://github.com/nix-community/poetry2nix/commit/b924859a347dc47f16ae582a233628a0307d83ab) | `overrides.secp256k1: Loosen up pytest-runner version constraint`                |
| [`7f68a230`](https://github.com/nix-community/poetry2nix/commit/7f68a230b721f34d02c2ef762cce56cb71441679) | `Updated patch for mypy 0.960+`                                                  |
| [`73fc21ab`](https://github.com/nix-community/poetry2nix/commit/73fc21abbed96024f6533da259d5b01b1337ae4d) | `Bump version to 1.30.0`                                                         |
| [`7eb113c8`](https://github.com/nix-community/poetry2nix/commit/7eb113c89012e5804ff0c560de2beda1d9e6de35) | `pkgs/poetry: Re-lock dependencies`                                              |
| [`ad9ca14c`](https://github.com/nix-community/poetry2nix/commit/ad9ca14cc5fd9965fa6cc4fec36b724eeb373777) | `overrides: Implement changes from https://github.com/NixOS/nixpkgs/pull/175305` |
| [`0ccfad7a`](https://github.com/nix-community/poetry2nix/commit/0ccfad7a6186f99a86b7aa8fb72a09b73210b57b) | `overrides.mypy: Fix build on 0.960`                                             |
| [`15e9c85d`](https://github.com/nix-community/poetry2nix/commit/15e9c85d26634073081801476555142a66e05e4e) | `overrides.pyfftw: Add override`                                                 |