### PR TITLE
chore(flake/utils): `1ed9fb19` -> `bee6a725`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1656065134,
+        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                                 |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`32dc3d46`](https://github.com/numtide/flake-utils/commit/32dc3d46b2854de460e1a0d03cea472fafea5acd) | `filterPackages: Fix a typo in the comment`                    |
| [`3b6a41d7`](https://github.com/numtide/flake-utils/commit/3b6a41d794bf4217b353f8b5477f903841a300fb) | `filterPackages: Do not use meta.hydraPlatforms for filtering` |
| [`3ff4550a`](https://github.com/numtide/flake-utils/commit/3ff4550a66be41ea42dfdd0393744623d00c0559) | `filterPackages: Add support for meta.badPlatforms`            |