### PR TITLE
chore(flake/utils): `7e2a3b3d` -> `6ee9ebb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1667077288,
+        "narHash": "sha256-bdC8sFNDpT0HK74u9fUkpbf1MEzVYJ+ka7NXCdgBoaA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                                     |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`6ee9ebb6`](https://github.com/numtide/flake-utils/commit/6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817) | `Bump cachix/install-nix-action from 17 to 18 (#81)`               |
| [`c0e246b9`](https://github.com/numtide/flake-utils/commit/c0e246b9b83f637f4681389ecabcb2681b4f3af0) | `Update each-system template to use new flake output system (#76)` |