### PR TITLE
chore(flags): add `indent-size` default value to `help` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Available flags are:
 ```
   --indent-size INDENT_SIZE, -i INDENT_SIZE
                         Sets the number of spaces to be used in indentation.
+                        Default is 4.
   --backup, -b          Beautysh will create a backup file in the same path as
                         the original.
   --check, -c           Beautysh will just check the files without doing any

--- a/beautysh/__init__.py
+++ b/beautysh/__init__.py
@@ -365,7 +365,7 @@ class Beautify:
             nargs=1,
             type=int,
             default=4,
-            help="Sets the number of spaces to be used in " "indentation.",
+            help="Sets the number of spaces to be used in " "indentation. Default is 4.",
         )
         parser.add_argument(
             "--backup",


### PR DESCRIPTION
This Pull Request aims to make the `--help` flag easier to use by adding the default value of the `--indent-size` flag. 

The default value of `--indent-size` is set to 4 in the code, it would be helpful to have it in the README file and the `--help` flag as well. See the code line: https://github.com/lovesegfault/beautysh/blob/master/beautysh/__init__.py#L367

```py
        parser.add_argument(
            "--indent-size",
            "-i",
            nargs=1,
            type=int,
            default=4,
            help="Sets the number of spaces to be used in " "indentation. Default is 4.",
```

Signed-off-by: Enes <ahmedenesturan@gmail.com>