### PR TITLE
chore(flake/utils): `5aed5285` -> `93a2b84f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                               | Commit Message                                                 |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`93a2b84f`](https://github.com/numtide/flake-utils/commit/93a2b84fc4b70d9e089d029deacc3583435c2ed6) | `Update README to reflect example for eachDefaultSystem (#90)` |
| [`3db36a8b`](https://github.com/numtide/flake-utils/commit/3db36a8b464d0c4532ba1c7dda728f4576d6d073) | `Bump cachix/install-nix-action from 18 to 19 (#87)`           |