### PR TITLE
build: depend on poetry-core instead of poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,5 +51,5 @@ line_length = 99
 skip_glob = ["/nix/store/*", "result/*"]
 
 [build-system]
-requires = ["poetry"]
+requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
The build-backend path is already correct. This was caught as I am working on switching nixpkgs to use [`build`](https://pypa-build.readthedocs.io/en/latest/) as the PEP 517 build front-end and relying on its build dependency validation.