### PR TITLE
Extend function name detection

### DIFF
--- a/beautysh/__init__.py
+++ b/beautysh/__init__.py
@@ -15,9 +15,9 @@ from colorama import Fore
 # 1) function keyword, NO open/closed parentheses, e.g.   function foo
 # 2) NO function keyword, open/closed parentheses, e.g.   foo()
 FUNCTION_STYLE_REGEX = [
-    r"\bfunction\s+(\w*)\s*\(\s*\)\s*",
-    r"\bfunction\s+(\w*)\s*",
-    r"\b\s*(\w*)\s*\(\s*\)\s*",
+    r"\bfunction\s+([\w@:]*)\s*\(\s*\)\s*",
+    r"\bfunction\s+([\w@:]*)\s*",
+    r"\b\s*([\w@:]*)\s*\(\s*\)\s*",
 ]
 
 FUNCTION_STYLE_REPLACEMENT = [r"function \g<1>() ", r"function \g<1> ", r"\g<1>() "]

--- a/tests/fixtures/function_styles_0.sh
+++ b/tests/fixtures/function_styles_0.sh
@@ -49,3 +49,11 @@ function function_style3c()
 function function_style3d() {
     echo "test"
 }
+
+function function::style3e() {
+    echo "test"
+}
+
+function function@style3f() {
+    echo "test"
+}

--- a/tests/fixtures/function_styles_1.sh
+++ b/tests/fixtures/function_styles_1.sh
@@ -49,3 +49,11 @@ function function_style3c
 function function_style3d {
     echo "test"
 }
+
+function function::style3e {
+    echo "test"
+}
+
+function function@style3f {
+    echo "test"
+}

--- a/tests/fixtures/function_styles_2.sh
+++ b/tests/fixtures/function_styles_2.sh
@@ -49,3 +49,11 @@ function_style3c()
 function_style3d() {
     echo "test"
 }
+
+function::style3e() {
+    echo "test"
+}
+
+function@style3f() {
+    echo "test"
+}

--- a/tests/fixtures/function_styles_raw.sh
+++ b/tests/fixtures/function_styles_raw.sh
@@ -49,3 +49,11 @@ function_style3c ()
 function_style3d () {
 	echo "test"
 }
+
+function::style3e () {
+	echo "test"
+}
+
+function@style3f () {
+	echo "test"
+}


### PR DESCRIPTION
Add `:` and `@` to the allowed characters for function names which are somewhat common.

The function names actually accept many more characters but those are less common.