### PR TITLE
fix: migrate to importlib.metadata since pkg_resources has deprecated

### DIFF
--- a/beautysh/__init__.py
+++ b/beautysh/__init__.py
@@ -6,7 +6,7 @@ import os
 import re
 import sys
 
-import pkg_resources  # part of setuptools
+from importlib.metadata import version, PackageNotFoundError  # part of setuptools
 from colorama import Fore
 
 # correct function style detection is obtained only if following regex are
@@ -348,8 +348,8 @@ class Beautify:
 
     def get_version(self):
         try:
-            return pkg_resources.require("beautysh")[0].version
-        except pkg_resources.DistributionNotFound:
+            return version("beautysh")
+        except PackageNotFoundError:
             return "Not Available"
 
     def main(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ include = ["LICENSE"]
 beautysh = "beautysh:main"
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
+python = "^3.10"
 colorama = "^0.4.4"
 types-colorama = "^0.4.3"
 types-setuptools = "^57.4.0"


### PR DESCRIPTION
Migrate to `importlib.metadata` and `Python 3.10`.